### PR TITLE
add Periphery support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ Let us know if you want to get involved.
 
 The plugin is designed to support Swift 5 syntax.
 
-| Feature             | Swift                                                        | Objective-C                                                  |
-|---------------------|--------------------------------------------------------------|--------------------------------------------------------------|
-| Size                | YES                                                          | YES                                                          |
-| Issues              | [SwiftLint 0.47.0](https://github.com/realm/SwiftLint) rules | [OCLint 22.02](https://oclint.org/) rules                    |
-| Tests               | YES                                                          | YES                                                          |
-| Coverage            | YES                                                          | YES                                                          |
-| Complexity          | IN PROGRESS                                                  | IN PROGRESS                                                  |
-| Syntax highlighting | IN PROGRESS                                                  | IN PROGRESS                                                  |
-| Security            | [mobsfscan 0.10.0](https://github.com/MobSF/mobsfscan) rules | [mobsfscan 0.10.0](https://github.com/MobSF/mobsfscan) rules |
+| Feature             | Swift                                                                                                                           | Objective-C                                                  |
+|---------------------|---------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| Size                | YES                                                                                                                             | YES                                                          |
+| Issues              | [SwiftLint 0.47.0](https://github.com/realm/SwiftLint) rules <br/> [Periphery](https://github.com/peripheryapp/periphery) rules | [OCLint 22.02](https://oclint.org/) rules                    |
+| Tests               | YES                                                                                                                             | YES                                                          |
+| Coverage            | YES                                                                                                                             | YES                                                          |
+| Complexity          | IN PROGRESS                                                                                                                     | IN PROGRESS                                                  |
+| Syntax highlighting | IN PROGRESS                                                                                                                     | IN PROGRESS                                                  |
+| Security            | [mobsfscan 0.10.0](https://github.com/MobSF/mobsfscan) rules                                                                    | [mobsfscan 0.10.0](https://github.com/MobSF/mobsfscan) rules |
 
 ## Requirements
 
@@ -74,6 +74,12 @@ mobsfscan is used to analyse Swift & Objective-C source files to find insecure c
 
 See install instructions [here](https://github.com/MobSF/mobsfscan).
 
+### Periphery
+
+Periphery is used to analyse Swift source files to find unused code.
+
+See install instructions [here](https://github.com/peripheryapp/periphery).
+
 ## Installation (on the server)
 
 SonarQube 7.9+ is required.
@@ -108,6 +114,10 @@ sonar.tests=iOSAppTests
 # Defaults to build
 # sonar.apple.xcodebuild.logPath=
 
+# Path to periphery.log file
+# Defaults to build
+# sonar.apple.periphery.logPath=
+
 # Encoding of the source code. Default is default system encoding.
 sonar.sourceEncoding=UTF-8
 ```
@@ -128,11 +138,23 @@ $ xcodebuild \
   -scheme MyApp \
   -sdk iphonesimulator \
   -destination 'platform=iOS Simulator,name=iPhone 11 Pro' \
-   COMPILER_INDEX_STORE_ENABLE=NO clean test | tee build/xcodebuild.log | xcpretty --report junit
+  -derivedDataPath ./derivedData \
+   clean test | tee build/xcodebuild.log | xcpretty --report junit
 
 # Generate coverage report to build/reports/cobertura.xml
 # Don't forget to activate 'Gather coverage' option in the app scheme
-slather coverage --cobertura-xml --output-directory build/reports --scheme MyApp MyApp.xcodeproj
+$ slather coverage --cobertura-xml --output-directory build/reports --scheme MyApp MyApp.xcodeproj
+
+# Saves Periphery log to build/periphery.log (this is necessary for Swift dead code analysis)
+# Don't forget to add --workspace to the build command if your project is part of a workspace
+$ periphery scan \
+  --project "MyApp.xcodeproj" \
+  --schemes "MyApp" \
+  --targets "MyApp" \
+  --skip-build \
+  --index-store-path ./derivedData/Index/DataStore \
+  --format xcode \
+  --quiet | tee build/periphery.log
   
 # Run the analysis and publish to the SonarQube server
 $ sonar-scanner

--- a/sonar-apple-plugin/src/main/java/fr/insideapp/sonarqube/apple/ApplePlugin.java
+++ b/sonar-apple-plugin/src/main/java/fr/insideapp/sonarqube/apple/ApplePlugin.java
@@ -33,6 +33,8 @@ import fr.insideapp.sonarqube.swift.lang.SwiftSensor;
 import fr.insideapp.sonarqube.swift.lang.issues.SwiftProfile;
 import fr.insideapp.sonarqube.swift.lang.issues.mobsfscan.MobSFScanSwiftRulesDefinition;
 import fr.insideapp.sonarqube.swift.lang.issues.mobsfscan.MobSFScanSwiftSensor;
+import fr.insideapp.sonarqube.swift.lang.issues.periphery.PeripheryRulesDefinition;
+import fr.insideapp.sonarqube.swift.lang.issues.periphery.PeripherySensor;
 import fr.insideapp.sonarqube.swift.lang.issues.swiftlint.SwiftLintRulesDefinition;
 import fr.insideapp.sonarqube.swift.lang.issues.swiftlint.SwiftLintSensor;
 import fr.insideapp.sonarqube.swift.lang.tests.SwiftTestFileFinder;
@@ -47,6 +49,8 @@ public class ApplePlugin implements Plugin {
     public static final String TESTS_SUBCATEGORY = "Tests";
 
     public static final String OCLINT_SUBCATEGORY = "OCLint";
+
+    public static final String PERIPHERY_SUBCATEGORY = "Periphery";
 
     public static final String COVERAGE_SUBCATEGORY = "Coverage";
 
@@ -65,6 +69,17 @@ public class ApplePlugin implements Plugin {
         // MobSFScan (Swift & Objective-C)
         context.addExtensions(MobSFScanSwiftSensor.class, MobSFScanSwiftRulesDefinition.class);
         context.addExtensions(MobSFScanObjectiveCSensor.class, MobSFScanObjectiveCRulesDefinition.class);
+
+        // Periphery
+        context.addExtension(
+                PropertyDefinition.builder(PeripherySensor.LOG_PATH_KEY)
+                        .name("periphery log")
+                        .description("Path to periphery log file. The path may be either absolute or relative to the project base directory.")
+                        .onQualifiers(Qualifiers.PROJECT)
+                        .category(APPLE_CATEGORY)
+                        .subCategory(PERIPHERY_SUBCATEGORY)
+                        .build());
+        context.addExtensions(PeripherySensor.class, PeripheryRulesDefinition.class);
 
         // OCLint
         context.addExtension(

--- a/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/ApplePluginTest.java
+++ b/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/ApplePluginTest.java
@@ -39,7 +39,7 @@ public class ApplePluginTest {
         ApplePlugin plugin = new ApplePlugin();
         plugin.define(context);
 
-        assertThat(context.getExtensions()).hasSize(19);
+        assertThat(context.getExtensions()).hasSize(22);
 
 
     }

--- a/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/RegexReportParser.java
+++ b/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/RegexReportParser.java
@@ -1,0 +1,64 @@
+/*
+ * SonarQube Apple Plugin - Enables analysis of Swift and Objective-C projects into SonarQube.
+ * Copyright © 2022 inside|app (contact@insideapp.fr)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package fr.insideapp.sonarqube.swift.lang.issues;
+
+import fr.insideapp.sonarqube.apple.commons.issues.ReportIssue;
+import fr.insideapp.sonarqube.apple.commons.issues.ReportParser;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public abstract class RegexReportParser implements ReportParser {
+
+    private final String regex;
+
+    public RegexReportParser(String regex) {
+        this.regex = regex;
+    }
+
+    public List<ReportIssue> parse(String input) {
+
+        List<ReportIssue> issues = new ArrayList<>();
+
+        String[] lines = input.split(System.getProperty("line.separator"));
+        Pattern pattern = Pattern.compile(regex);
+        for (String line : lines) {
+            Matcher matcher = pattern.matcher(line);
+            while (matcher.find()) {
+                String filePath = filePath(matcher);
+                int lineNum = lineNum(matcher);
+                String message = message(matcher);
+                String ruleId = ruleId(matcher);
+                issues.add(new ReportIssue(ruleId, message, filePath, lineNum));
+            }
+        }
+
+        return issues;
+    }
+
+    public abstract String filePath(Matcher matcher);
+
+    public abstract int lineNum(Matcher matcher);
+
+    public abstract String message(Matcher matcher);
+
+    public abstract String ruleId(Matcher matcher);
+
+}

--- a/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/RegexReportParser.java
+++ b/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/RegexReportParser.java
@@ -29,7 +29,7 @@ public abstract class RegexReportParser implements ReportParser {
 
     private final String regex;
 
-    public RegexReportParser(String regex) {
+    protected RegexReportParser(String regex) {
         this.regex = regex;
     }
 
@@ -42,9 +42,9 @@ public abstract class RegexReportParser implements ReportParser {
         for (String line : lines) {
             Matcher matcher = pattern.matcher(line);
             while (matcher.find()) {
-                String filePath = filePath(matcher);
-                int lineNum = lineNum(matcher);
-                String message = message(matcher);
+                String filePath = matcher.group(1);
+                int lineNum = Integer.parseInt(matcher.group(2));
+                String message = matcher.group(5);
                 String ruleId = ruleId(matcher);
                 issues.add(new ReportIssue(ruleId, message, filePath, lineNum));
             }
@@ -52,12 +52,6 @@ public abstract class RegexReportParser implements ReportParser {
 
         return issues;
     }
-
-    public abstract String filePath(Matcher matcher);
-
-    public abstract int lineNum(Matcher matcher);
-
-    public abstract String message(Matcher matcher);
 
     public abstract String ruleId(Matcher matcher);
 

--- a/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/SwiftProfile.java
+++ b/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/SwiftProfile.java
@@ -21,6 +21,7 @@ import fr.insideapp.sonarqube.apple.commons.issues.MobSFScanRulesDefinition;
 import fr.insideapp.sonarqube.apple.commons.issues.RepositoryRule;
 import fr.insideapp.sonarqube.apple.commons.issues.RepositoryRuleParser;
 import fr.insideapp.sonarqube.swift.lang.Swift;
+import fr.insideapp.sonarqube.swift.lang.issues.periphery.PeripheryRulesDefinition;
 import fr.insideapp.sonarqube.swift.lang.issues.swiftlint.SwiftLintRulesDefinition;
 import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition;
 import org.sonar.api.utils.log.Logger;
@@ -59,6 +60,17 @@ public class SwiftProfile implements BuiltInQualityProfilesDefinition {
             }
         } catch (IOException e) {
             LOGGER.error("Failed to load MobSFScan rules (for Swift)", e);
+        }
+
+        // Periphery rules
+        try {
+            List<RepositoryRule> rules = repositoryRuleParser.parse(PeripheryRulesDefinition.RULES_PATH);
+            for (RepositoryRule r: rules) {
+                NewBuiltInActiveRule rule = profile.activateRule("Periphery", r.getKey());
+                rule.overrideSeverity(r.getSeverity());
+            }
+        } catch (IOException e) {
+            LOGGER.error("Failed to load Periphery rules", e);
         }
 
         profile.setDefault(true);

--- a/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/SwiftProfile.java
+++ b/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/SwiftProfile.java
@@ -17,9 +17,7 @@
  */
 package fr.insideapp.sonarqube.swift.lang.issues;
 
-import fr.insideapp.sonarqube.apple.commons.issues.MobSFScanRulesDefinition;
-import fr.insideapp.sonarqube.apple.commons.issues.RepositoryRule;
-import fr.insideapp.sonarqube.apple.commons.issues.RepositoryRuleParser;
+import fr.insideapp.sonarqube.apple.commons.issues.*;
 import fr.insideapp.sonarqube.swift.lang.Swift;
 import fr.insideapp.sonarqube.swift.lang.issues.periphery.PeripheryRulesDefinition;
 import fr.insideapp.sonarqube.swift.lang.issues.swiftlint.SwiftLintRulesDefinition;
@@ -28,7 +26,10 @@ import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class SwiftProfile implements BuiltInQualityProfilesDefinition {
 

--- a/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/SwiftProfile.java
+++ b/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/SwiftProfile.java
@@ -26,10 +26,7 @@ import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class SwiftProfile implements BuiltInQualityProfilesDefinition {
 

--- a/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripheryReportParser.java
+++ b/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripheryReportParser.java
@@ -17,36 +17,34 @@
  */
 package fr.insideapp.sonarqube.swift.lang.issues.periphery;
 
-import fr.insideapp.sonarqube.apple.commons.issues.ReportIssue;
-import fr.insideapp.sonarqube.apple.commons.issues.ReportParser;
+import fr.insideapp.sonarqube.swift.lang.issues.RegexReportParser;
 
-import java.util.*;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-public class PeripheryReportParser implements ReportParser {
+public class PeripheryReportParser extends RegexReportParser {
+
+    public PeripheryReportParser() {
+        super("(.*.swift):(\\w+):(\\w+): (warning): (.*)");
+    }
 
     @Override
-    public List<ReportIssue> parse(String input) {
+    public String filePath(Matcher matcher) {
+        return matcher.group(1);
+    }
 
-        List<ReportIssue> issues = new ArrayList<>();
+    @Override
+    public int lineNum(Matcher matcher) {
+        return Integer.parseInt(matcher.group(2));
+    }
 
-        String[] lines = input.split(System.getProperty("line.separator"));
-        Pattern pattern = Pattern.compile("(.*.swift):(\\w+):(\\w+): (warning): (.*)");
-        for (String line : lines) {
-            Matcher matcher = pattern.matcher(line);
-            while (matcher.find()) {
-                String filePath = matcher.group(1);
-                int lineNum = Integer.parseInt(matcher.group(2));
-                String message = matcher.group(5);
-                /*
-                 Periphery doesn't provide the ruleId at the moment
-                */
-                String ruleId = "unused";
-                issues.add(new ReportIssue(ruleId, message, filePath, lineNum));
-            }
-        }
+    @Override
+    public String message(Matcher matcher) {
+        return matcher.group(5);
+    }
 
-        return issues;
+    @Override
+    public String ruleId(Matcher matcher) {
+        // periphery doesn't provide the ruleId at the moment
+        return "unused";
     }
 }

--- a/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripheryReportParser.java
+++ b/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripheryReportParser.java
@@ -1,9 +1,24 @@
+/*
+ * SonarQube Apple Plugin - Enables analysis of Swift and Objective-C projects into SonarQube.
+ * Copyright © 2022 inside|app (contact@insideapp.fr)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package fr.insideapp.sonarqube.swift.lang.issues.periphery;
 
 import fr.insideapp.sonarqube.apple.commons.issues.ReportIssue;
 import fr.insideapp.sonarqube.apple.commons.issues.ReportParser;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
 
 import java.util.*;
 import java.util.regex.Matcher;
@@ -26,7 +41,6 @@ public class PeripheryReportParser implements ReportParser {
                 String message = matcher.group(5);
                 /*
                  Periphery doesn't provide the ruleId at the moment
-                 TODO: add ruleId when it will be provided
                 */
                 String ruleId = "unused";
                 issues.add(new ReportIssue(ruleId, message, filePath, lineNum));

--- a/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripheryReportParser.java
+++ b/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripheryReportParser.java
@@ -1,0 +1,38 @@
+package fr.insideapp.sonarqube.swift.lang.issues.periphery;
+
+import fr.insideapp.sonarqube.apple.commons.issues.ReportIssue;
+import fr.insideapp.sonarqube.apple.commons.issues.ReportParser;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class PeripheryReportParser implements ReportParser {
+
+    @Override
+    public List<ReportIssue> parse(String input) {
+
+        List<ReportIssue> issues = new ArrayList<>();
+
+        String[] lines = input.split(System.getProperty("line.separator"));
+        Pattern pattern = Pattern.compile("(.*.swift):(\\w+):(\\w+): (warning): (.*)");
+        for (String line : lines) {
+            Matcher matcher = pattern.matcher(line);
+            while (matcher.find()) {
+                String filePath = matcher.group(1);
+                int lineNum = Integer.parseInt(matcher.group(2));
+                String message = matcher.group(5);
+                /*
+                 Periphery doesn't provide the ruleId at the moment
+                 TODO: add ruleId when it will be provided
+                */
+                String ruleId = "unused";
+                issues.add(new ReportIssue(ruleId, message, filePath, lineNum));
+            }
+        }
+
+        return issues;
+    }
+}

--- a/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripheryReportParser.java
+++ b/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripheryReportParser.java
@@ -28,21 +28,6 @@ public class PeripheryReportParser extends RegexReportParser {
     }
 
     @Override
-    public String filePath(Matcher matcher) {
-        return matcher.group(1);
-    }
-
-    @Override
-    public int lineNum(Matcher matcher) {
-        return Integer.parseInt(matcher.group(2));
-    }
-
-    @Override
-    public String message(Matcher matcher) {
-        return matcher.group(5);
-    }
-
-    @Override
     public String ruleId(Matcher matcher) {
         // periphery doesn't provide the ruleId at the moment
         return "unused";

--- a/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripheryRulesDefinition.java
+++ b/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripheryRulesDefinition.java
@@ -1,0 +1,17 @@
+package fr.insideapp.sonarqube.swift.lang.issues.periphery;
+
+import fr.insideapp.sonarqube.apple.commons.issues.JSONRulesDefinition;
+import fr.insideapp.sonarqube.swift.lang.Swift;
+
+public class PeripheryRulesDefinition extends JSONRulesDefinition {
+
+    public static final String REPOSITORY_KEY = "Periphery";
+    public static final String REPOSITORY_NAME = REPOSITORY_KEY;
+
+    public static final String RULES_PATH = "/periphery-rules.json";
+
+    public PeripheryRulesDefinition() {
+        super(REPOSITORY_KEY, REPOSITORY_NAME, Swift.KEY, RULES_PATH);
+    }
+
+}

--- a/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripheryRulesDefinition.java
+++ b/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripheryRulesDefinition.java
@@ -1,3 +1,20 @@
+/*
+ * SonarQube Apple Plugin - Enables analysis of Swift and Objective-C projects into SonarQube.
+ * Copyright © 2022 inside|app (contact@insideapp.fr)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package fr.insideapp.sonarqube.swift.lang.issues.periphery;
 
 import fr.insideapp.sonarqube.apple.commons.issues.JSONRulesDefinition;

--- a/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripherySensor.java
+++ b/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripherySensor.java
@@ -1,10 +1,26 @@
+/*
+ * SonarQube Apple Plugin - Enables analysis of Swift and Objective-C projects into SonarQube.
+ * Copyright © 2022 inside|app (contact@insideapp.fr)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package fr.insideapp.sonarqube.swift.lang.issues.periphery;
 
 import fr.insideapp.sonarqube.apple.commons.issues.ReportIssue;
 import fr.insideapp.sonarqube.apple.commons.issues.ReportIssueRecorder;
 import fr.insideapp.sonarqube.swift.lang.Swift;
 import org.apache.commons.io.IOUtils;
-import org.buildobjects.process.ProcBuilder;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorContext;

--- a/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripherySensor.java
+++ b/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripherySensor.java
@@ -1,0 +1,80 @@
+package fr.insideapp.sonarqube.swift.lang.issues.periphery;
+
+import fr.insideapp.sonarqube.apple.commons.issues.ReportIssue;
+import fr.insideapp.sonarqube.apple.commons.issues.ReportIssueRecorder;
+import fr.insideapp.sonarqube.swift.lang.Swift;
+import org.apache.commons.io.IOUtils;
+import org.buildobjects.process.ProcBuilder;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.sensor.Sensor;
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.batch.sensor.SensorDescriptor;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PeripherySensor implements Sensor {
+
+    private static final Logger LOGGER = Loggers.get(PeripherySensor.class);
+    private static final String DEFAULT_LOG_PATH = "build";
+
+    public static final String LOG_PATH_KEY = "sonar.apple.periphery.logPath";
+
+    public static final String LOG_FILENAME = "periphery.log";
+
+    private final SensorContext context;
+
+    public PeripherySensor(SensorContext context) {
+        this.context = context;
+    }
+
+    protected String logPath() {
+        return context.config()
+                .get(LOG_PATH_KEY)
+                .orElse(DEFAULT_LOG_PATH);
+    }
+
+    @Override
+    public void describe(SensorDescriptor sensorDescriptor) {
+        sensorDescriptor.onlyOnLanguage(Swift.KEY).name("Periphery Sensor").onlyOnFileType(InputFile.Type.MAIN);
+    }
+
+    @Override
+    public void execute(SensorContext sensorContext) {
+
+        try {
+            List<ReportIssue> issues = runAnalysis();
+            ReportIssueRecorder issueRecorder = new ReportIssueRecorder(sensorContext);
+            issueRecorder.recordIssues(issues, PeripheryRulesDefinition.REPOSITORY_KEY);
+        } catch (IOException e) {
+            LOGGER.error(e.getMessage(), e);
+        }
+    }
+
+    private List<ReportIssue> runAnalysis() throws IOException {
+
+        // Look for periphery.log file
+        File peripheryLogFile = new File(logPath(), LOG_FILENAME);
+        if (!peripheryLogFile.exists()) {
+            LOGGER.error("Failed to locate periphery.log file at {}", peripheryLogFile.getAbsolutePath());
+            return new ArrayList<>();
+        }
+
+        try (InputStream is = new FileInputStream((peripheryLogFile))) {
+            // Parse issues
+            String peripheryLogContent = IOUtils.toString(is, StandardCharsets.UTF_8);
+            List<ReportIssue> issues = new PeripheryReportParser().parse(peripheryLogContent);
+            LOGGER.info("Found issues: {}", issues.size());
+            return issues;
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+}

--- a/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/swiftlint/SwiftLintReportParser.java
+++ b/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/swiftlint/SwiftLintReportParser.java
@@ -17,34 +17,34 @@
  */
 package fr.insideapp.sonarqube.swift.lang.issues.swiftlint;
 
-import fr.insideapp.sonarqube.apple.commons.issues.ReportIssue;
-import fr.insideapp.sonarqube.apple.commons.issues.ReportParser;
+import fr.insideapp.sonarqube.swift.lang.issues.RegexReportParser;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-public class SwiftLintReportParser implements ReportParser {
+public class SwiftLintReportParser extends RegexReportParser {
+
+    public SwiftLintReportParser() {
+        super("(.*.swift):(\\w+):(\\w+): (warning|error): (.*) \\((\\w+)\\)");
+    }
 
     @Override
-    public List<ReportIssue> parse(String input) {
-
-        List<ReportIssue> issues = new ArrayList<>();
-
-        String[] lines = input.split(System.getProperty("line.separator"));
-        Pattern pattern = Pattern.compile("(.*.swift):(\\w+):(\\w+): (warning|error): (.*) \\((\\w+)\\)");
-        for (String line : lines) {
-            Matcher matcher = pattern.matcher(line);
-            while (matcher.find()) {
-                String filePath = matcher.group(1);
-                int lineNum = Integer.parseInt(matcher.group(2));
-                String message = matcher.group(5);
-                String ruleId = matcher.group(6);
-                issues.add(new ReportIssue(ruleId, message, filePath, lineNum));
-            }
-        }
-
-        return issues;
+    public String filePath(Matcher matcher) {
+        return matcher.group(1);
     }
+
+    @Override
+    public int lineNum(Matcher matcher) {
+        return Integer.parseInt(matcher.group(2));
+    }
+
+    @Override
+    public String message(Matcher matcher) {
+        return matcher.group(5);
+    }
+
+    @Override
+    public String ruleId(Matcher matcher) {
+        return matcher.group(6);
+    }
+
 }

--- a/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/swiftlint/SwiftLintReportParser.java
+++ b/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/lang/issues/swiftlint/SwiftLintReportParser.java
@@ -28,21 +28,6 @@ public class SwiftLintReportParser extends RegexReportParser {
     }
 
     @Override
-    public String filePath(Matcher matcher) {
-        return matcher.group(1);
-    }
-
-    @Override
-    public int lineNum(Matcher matcher) {
-        return Integer.parseInt(matcher.group(2));
-    }
-
-    @Override
-    public String message(Matcher matcher) {
-        return matcher.group(5);
-    }
-
-    @Override
     public String ruleId(Matcher matcher) {
         return matcher.group(6);
     }

--- a/swift-lang/src/main/resources/periphery-rules.json
+++ b/swift-lang/src/main/resources/periphery-rules.json
@@ -1,0 +1,13 @@
+[
+    {
+        "key": "unused",
+        "name": "Unused",
+        "severity": "MAJOR",
+        "description": "This code is never unused",
+        "debt": {
+            "function": "CONSTANT_ISSUE",
+            "offset": "1min"
+        },
+        "type": "CODE_SMELL"
+    }
+]

--- a/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/lang/issues/ReportParserTestHelper.java
+++ b/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/lang/issues/ReportParserTestHelper.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package fr.insideapp.sonarqube.swift.lang.issues.swiftlint;
+package fr.insideapp.sonarqube.swift.lang.issues;
 
 import fr.insideapp.sonarqube.apple.commons.issues.ReportIssue;
 

--- a/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripheryReportParserTest.java
+++ b/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripheryReportParserTest.java
@@ -1,3 +1,20 @@
+/*
+ * SonarQube Apple Plugin - Enables analysis of Swift and Objective-C projects into SonarQube.
+ * Copyright © 2022 inside|app (contact@insideapp.fr)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package fr.insideapp.sonarqube.swift.lang.issues.periphery;
 
 import fr.insideapp.sonarqube.apple.commons.issues.ReportIssue;

--- a/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripheryReportParserTest.java
+++ b/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripheryReportParserTest.java
@@ -1,0 +1,37 @@
+package fr.insideapp.sonarqube.swift.lang.issues.periphery;
+
+import fr.insideapp.sonarqube.apple.commons.issues.ReportIssue;
+import fr.insideapp.sonarqube.swift.lang.issues.ReportParserTestHelper;
+import fr.insideapp.sonarqube.swift.lang.issues.swiftlint.SwiftLintReportParser;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PeripheryReportParserTest {
+
+    private static final String FILE_PATH = "/SQApp/SQApp/SQAppApp.swift";
+
+    @Test
+    public void parse() {
+
+        String input = "/SQApp/SQApp/SQAppApp.swift:23:1: warning: Property 'myProperty' is assigned, but never used\n" +
+                "/SQApp/SQApp/SQAppApp.swift:17:9: warning: Function 'myFunction(param1:param2:)' is unused";
+
+        PeripheryReportParser parser = new PeripheryReportParser();
+
+        List<ReportIssue> issues = parser.parse(input);
+        assertThat(issues).hasSize(2);
+
+        ReportParserTestHelper.assertFilePath(issues.get(0), FILE_PATH);
+        ReportParserTestHelper.assertLineNumber(issues.get(0), 23);
+        ReportParserTestHelper.assertRuleId(issues.get(0), "unused");
+        ReportParserTestHelper.assertMessage(issues.get(0), "Property 'myProperty' is assigned, but never used");
+
+        ReportParserTestHelper.assertFilePath(issues.get(1), FILE_PATH);
+        ReportParserTestHelper.assertLineNumber(issues.get(1), 17);
+        ReportParserTestHelper.assertRuleId(issues.get(1), "unused");
+        ReportParserTestHelper.assertMessage(issues.get(1), "Function 'myFunction(param1:param2:)' is unused");
+    }
+}

--- a/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripheryReportParserTest.java
+++ b/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripheryReportParserTest.java
@@ -19,7 +19,6 @@ package fr.insideapp.sonarqube.swift.lang.issues.periphery;
 
 import fr.insideapp.sonarqube.apple.commons.issues.ReportIssue;
 import fr.insideapp.sonarqube.swift.lang.issues.ReportParserTestHelper;
-import fr.insideapp.sonarqube.swift.lang.issues.swiftlint.SwiftLintReportParser;
 import org.junit.Test;
 
 import java.util.List;

--- a/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripheryRulesDefinitionTest.java
+++ b/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripheryRulesDefinitionTest.java
@@ -1,3 +1,20 @@
+/*
+ * SonarQube Apple Plugin - Enables analysis of Swift and Objective-C projects into SonarQube.
+ * Copyright © 2022 inside|app (contact@insideapp.fr)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package fr.insideapp.sonarqube.swift.lang.issues.periphery;
 
 import org.junit.Test;

--- a/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripheryRulesDefinitionTest.java
+++ b/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripheryRulesDefinitionTest.java
@@ -1,0 +1,25 @@
+package fr.insideapp.sonarqube.swift.lang.issues.periphery;
+
+import org.junit.Test;
+import org.sonar.api.server.rule.RulesDefinition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PeripheryRulesDefinitionTest {
+
+    @Test
+    public void define() {
+
+        PeripheryRulesDefinition rulesDefinition = new PeripheryRulesDefinition();
+        RulesDefinition.Context context = new RulesDefinition.Context();
+        rulesDefinition.define(context);
+
+        RulesDefinition.Repository repository = context.repository("Periphery");
+        assertThat(repository).isNotNull();
+        assertThat(repository.name()).isEqualTo("Periphery");
+        assertThat(repository.language()).isEqualTo("swift");
+        assertThat(repository.rules()).isNotEmpty();
+
+
+    }
+}

--- a/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripherySensorTest.java
+++ b/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripherySensorTest.java
@@ -1,3 +1,20 @@
+/*
+ * SonarQube Apple Plugin - Enables analysis of Swift and Objective-C projects into SonarQube.
+ * Copyright © 2022 inside|app (contact@insideapp.fr)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package fr.insideapp.sonarqube.swift.lang.issues.periphery;
 
 import org.junit.Test;

--- a/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripherySensorTest.java
+++ b/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/lang/issues/periphery/PeripherySensorTest.java
@@ -1,0 +1,23 @@
+package fr.insideapp.sonarqube.swift.lang.issues.periphery;
+
+import org.junit.Test;
+import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
+import org.sonar.api.batch.sensor.internal.SensorContextTester;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PeripherySensorTest {
+
+    private static final String BASE_DIR = "src/test/resources/swift";
+
+    @Test
+    public void describe() {
+        PeripherySensor sensor = new PeripherySensor(SensorContextTester.create(new File(BASE_DIR)));
+        DefaultSensorDescriptor descriptor = new DefaultSensorDescriptor();
+        sensor.describe(descriptor);
+        assertThat(descriptor.name()).isEqualTo("Periphery Sensor");
+    }
+
+}

--- a/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/lang/issues/swiftlint/SwiftLintReportParserTest.java
+++ b/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/lang/issues/swiftlint/SwiftLintReportParserTest.java
@@ -19,6 +19,7 @@ package fr.insideapp.sonarqube.swift.lang.issues.swiftlint;
 
 import fr.insideapp.sonarqube.apple.commons.issues.ReportIssue;
 
+import fr.insideapp.sonarqube.swift.lang.issues.ReportParserTestHelper;
 import org.junit.Test;
 
 import java.util.List;


### PR DESCRIPTION
# Periphery support

- [x] Create RuleDefinition and load rules in builtin profile
- [x] Create ReportParser
- [x] Create Sensor (parse results and record issues)

# References

- https://github.com/peripheryapp/periphery

# Note

At the moment, the sensor only define one rule, because the Periphery does not provide the key of the violation in its results. This is OK because there is only four rules for now, and all of them can be translated into "unused code".
If the key is added in the results, it might be interesting to split them like SwiftLint does.

# DoD

- [x] Unit tests
- [x] Documentation (and developer documentation) update

# Rendering

![Capture d’écran 2022-05-05 à 16 49 38](https://user-images.githubusercontent.com/2591243/166953133-64d8f87a-1e84-4061-af0d-e0a306d7917b.png)

