### PR TITLE
Update Swiftlint & mobsfscan

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ The plugin is designed to support Swift 5 syntax.
 | Feature             | Swift                                                                                                                           | Objective-C                                                  |
 |---------------------|---------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
 | Size                | YES                                                                                                                             | YES                                                          |
-| Issues              | [SwiftLint 0.47.1](https://github.com/realm/SwiftLint) rules <br/> [Periphery](https://github.com/peripheryapp/periphery) rules | [OCLint 22.02](https://oclint.org/) rules                    |
+| Issues              | [SwiftLint 0.48.0](https://github.com/realm/SwiftLint) rules <br/> [Periphery](https://github.com/peripheryapp/periphery) rules | [OCLint 22.02](https://oclint.org/) rules                    |
 | Tests               | YES                                                                                                                             | YES                                                          |
 | Coverage            | YES                                                                                                                             | YES                                                          |
 | Complexity          | YES                                                                                                                             | YES                                                          |
 | Syntax highlighting | YES                                                                                                                             | YES                                                          |
-| Security            | [mobsfscan 0.10.0](https://github.com/MobSF/mobsfscan) rules                                                                    | [mobsfscan 0.10.0](https://github.com/MobSF/mobsfscan) rules |
+| Security            | [mobsfscan 0.11.0](https://github.com/MobSF/mobsfscan) rules                                                                    | [mobsfscan 0.10.0](https://github.com/MobSF/mobsfscan) rules |
 
 ## Requirements
 

--- a/swift-lang/src/main/resources/swiftlint-rules.json
+++ b/swift-lang/src/main/resources/swiftlint-rules.json
@@ -2341,5 +2341,16 @@
             "offset": "5min",
             "function": "CONSTANT_ISSUE"
         }
+    },
+    {
+        "key": "void_function_in_ternary",
+        "name": "Void Function in Ternary",
+        "description": "Using ternary to call Void functions should be avoided.",
+        "severity": "MINOR",
+        "type": "CODE_SMELL",
+        "debt": {
+            "offset": "5min",
+            "function": "CONSTANT_ISSUE"
+        }
     }
 ]


### PR DESCRIPTION
This PR updates:
- SwiftLint rules to support 0.48.0.
- mobsfscan to support 0.11.0 ; no new rules for this version, but the support for M1 was added
