### PR TITLE
Refact OCLintSensor to use SonarQube dependency injection system

### DIFF
--- a/commons/src/main/java/fr/insideapp/sonarqube/apple/commons/ExtensionProvider.java
+++ b/commons/src/main/java/fr/insideapp/sonarqube/apple/commons/ExtensionProvider.java
@@ -1,3 +1,20 @@
+/*
+ * SonarQube Apple Plugin - Enables analysis of Swift and Objective-C projects into SonarQube.
+ * Copyright © 2022 inside|app (contact@insideapp.fr)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package fr.insideapp.sonarqube.apple.commons;
 
 import java.util.List;

--- a/commons/src/main/java/fr/insideapp/sonarqube/apple/commons/ExtensionProvider.java
+++ b/commons/src/main/java/fr/insideapp/sonarqube/apple/commons/ExtensionProvider.java
@@ -1,0 +1,11 @@
+package fr.insideapp.sonarqube.apple.commons;
+
+import java.util.List;
+
+public interface ExtensionProvider {
+
+    String APPLE_CATEGORY = "Apple";
+
+    List<Object> extensions();
+
+}

--- a/commons/src/main/java/fr/insideapp/sonarqube/apple/commons/RunningSourcesCLISensor.java
+++ b/commons/src/main/java/fr/insideapp/sonarqube/apple/commons/RunningSourcesCLISensor.java
@@ -60,8 +60,8 @@ public abstract class RunningSourcesCLISensor implements Sensor {
     public void execute(SensorContext sensorContext) {
         try {
             List<ReportIssue> issues = runAnalysis(sensorContext);
-            ReportIssueRecorder issueRecorder = new ReportIssueRecorder(sensorContext);
-            issueRecorder.recordIssues(issues, repository());
+            ReportIssueRecorder issueRecorder = new ReportIssueRecorder();
+            issueRecorder.recordIssues(issues, repository(), sensorContext);
         } catch (IOException e) {
             LOGGER.error(e.getMessage(), e);
         }

--- a/commons/src/main/java/fr/insideapp/sonarqube/apple/commons/issues/ReportIssueRecorder.java
+++ b/commons/src/main/java/fr/insideapp/sonarqube/apple/commons/issues/ReportIssueRecorder.java
@@ -26,21 +26,18 @@ import org.sonar.api.batch.sensor.issue.NewIssue;
 import org.sonar.api.batch.sensor.issue.NewIssueLocation;
 import org.sonar.api.batch.sensor.issue.internal.DefaultIssueLocation;
 import org.sonar.api.rule.RuleKey;
+import org.sonar.api.scanner.ScannerSide;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 
 import java.util.List;
 
-public class ReportIssueRecorder {
+@ScannerSide
+public final class ReportIssueRecorder {
 
     private static final Logger LOGGER = Loggers.get(ReportIssueRecorder.class);
-    private final SensorContext sensorContext;
 
-    public ReportIssueRecorder(SensorContext sensorContext) {
-        this.sensorContext = sensorContext;
-    }
-
-    public void recordIssues(List<ReportIssue> issues, String repository) {
+    public void recordIssues(List<ReportIssue> issues, String repository, SensorContext sensorContext) {
 
         final FileSystem fs = sensorContext.fileSystem();
         final FilePredicates predicates = fs.predicates();

--- a/commons/src/test/java/fr/insideapp/sonarqube/apple/commons/issues/ReportIssueRecorderTest.java
+++ b/commons/src/test/java/fr/insideapp/sonarqube/apple/commons/issues/ReportIssueRecorderTest.java
@@ -50,8 +50,8 @@ public class ReportIssueRecorderTest {
         List<ReportIssue> issues = new ArrayList<>();
         issues.add(new ReportIssue("ruleId", "message", testFile.path().toString(), 3));
 
-        ReportIssueRecorder recorder = new ReportIssueRecorder(context);
-        recorder.recordIssues(issues, "TestRepo");
+        ReportIssueRecorder recorder = new ReportIssueRecorder();
+        recorder.recordIssues(issues, "TestRepo", context);
 
         assertThat(context.allIssues()).hasSize(1);
 

--- a/objc-lang/src/main/java/fr/insideapp/sonarqube/objc/issues/oclint/OCLintExtensionProvider.java
+++ b/objc-lang/src/main/java/fr/insideapp/sonarqube/objc/issues/oclint/OCLintExtensionProvider.java
@@ -1,0 +1,45 @@
+package fr.insideapp.sonarqube.objc.issues.oclint;
+
+import fr.insideapp.sonarqube.apple.commons.ExtensionProvider;
+import fr.insideapp.sonarqube.objc.issues.oclint.implementations.OCLintExtractor;
+import fr.insideapp.sonarqube.objc.issues.oclint.implementations.OCLintJSONDatabaseBuilder;
+import fr.insideapp.sonarqube.objc.issues.oclint.implementations.OCLintReportParser;
+import org.sonar.api.config.Configuration;
+import org.sonar.api.config.PropertyDefinition;
+import org.sonar.api.resources.Qualifiers;
+
+import java.util.Arrays;
+import java.util.List;
+
+public final class OCLintExtensionProvider implements ExtensionProvider {
+
+    private static final String JSON_COMPILATION_DATABASE_KEY = "sonar.apple.jsonCompilationDatabasePath";
+    private static final String DEFAULT_JSON_COMPILATION_DATABASE_PATH = "build/json_compilation_database";
+    private static final PropertyDefinition JSON_COMPILATION_DATABASE_PROPERTY = PropertyDefinition
+            .builder(JSON_COMPILATION_DATABASE_KEY)
+            .name("JSON Compilation Database path")
+            .description("Path to JSON Compilation Database folder. The path may be either absolute or relative to the project base directory.")
+            .defaultValue(DEFAULT_JSON_COMPILATION_DATABASE_PATH)
+            .onQualifiers(Qualifiers.PROJECT)
+            .category(APPLE_CATEGORY)
+            .subCategory("OCLint")
+            .build();
+
+    public List<Object> extensions() {
+        return Arrays.asList(
+                JSON_COMPILATION_DATABASE_PROPERTY,
+                OCLintRulesDefinition.class,
+                OCLintJSONDatabaseBuilder.class,
+                OCLintExtractor.class,
+                OCLintReportParser.class,
+                OCLintSensor.class
+        );
+    }
+
+    public static String jsonCompilationDatabasePath(Configuration configuration) {
+        return configuration
+                .get(JSON_COMPILATION_DATABASE_KEY)
+                .orElse(DEFAULT_JSON_COMPILATION_DATABASE_PATH);
+    }
+
+}

--- a/objc-lang/src/main/java/fr/insideapp/sonarqube/objc/issues/oclint/OCLintExtensionProvider.java
+++ b/objc-lang/src/main/java/fr/insideapp/sonarqube/objc/issues/oclint/OCLintExtensionProvider.java
@@ -1,3 +1,20 @@
+/*
+ * SonarQube Apple Plugin - Enables analysis of Swift and Objective-C projects into SonarQube.
+ * Copyright © 2022 inside|app (contact@insideapp.fr)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package fr.insideapp.sonarqube.objc.issues.oclint;
 
 import fr.insideapp.sonarqube.apple.commons.ExtensionProvider;

--- a/objc-lang/src/main/java/fr/insideapp/sonarqube/objc/issues/oclint/implementations/OCLintJSONDatabaseBuilder.java
+++ b/objc-lang/src/main/java/fr/insideapp/sonarqube/objc/issues/oclint/implementations/OCLintJSONDatabaseBuilder.java
@@ -15,11 +15,13 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package fr.insideapp.sonarqube.objc.issues.oclint;
+package fr.insideapp.sonarqube.objc.issues.oclint.implementations;
 
 import fr.insideapp.sonarqube.apple.commons.ExtensionFileFilter;
+import fr.insideapp.sonarqube.objc.issues.oclint.interfaces.OCLintJSONDatabaseBuildable;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RegExUtils;
+import org.sonar.api.scanner.ScannerSide;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 
@@ -30,7 +32,8 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.regex.Pattern;
 
-public final class OCLintJSONDatabaseBuilder {
+@ScannerSide
+public final class OCLintJSONDatabaseBuilder implements OCLintJSONDatabaseBuildable {
 
     private static final Pattern CLEAN_PATTERN = Pattern.compile("(\"-index-store-path.*DataStore\", |\"-index-unit-output-path.*\\.o\", )");
 

--- a/objc-lang/src/main/java/fr/insideapp/sonarqube/objc/issues/oclint/implementations/OCLintReportParser.java
+++ b/objc-lang/src/main/java/fr/insideapp/sonarqube/objc/issues/oclint/implementations/OCLintReportParser.java
@@ -15,10 +15,12 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package fr.insideapp.sonarqube.objc.issues.oclint;
+package fr.insideapp.sonarqube.objc.issues.oclint.implementations;
 
 import fr.insideapp.sonarqube.apple.commons.issues.ReportIssue;
+import fr.insideapp.sonarqube.objc.issues.oclint.interfaces.OCLintReportParsable;
 import fr.insideapp.sonarqube.objc.issues.oclint.models.OCLintReport;
+import org.sonar.api.scanner.ScannerSide;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 
@@ -26,8 +28,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-
-public class OCLintReportParser {
+@ScannerSide
+public class OCLintReportParser implements OCLintReportParsable {
 
     private static final Logger LOGGER = Loggers.get(OCLintReportParser.class);
 
@@ -39,8 +41,7 @@ public class OCLintReportParser {
 
         LOGGER.info("{} OCLint violation(s) to handle", report.violations.length);
 
-        return Arrays.asList(report.violations)
-                .stream()
+        return Arrays.stream(report.violations)
                 .map(violation ->
                     new ReportIssue(
                             violation.rule,

--- a/objc-lang/src/main/java/fr/insideapp/sonarqube/objc/issues/oclint/interfaces/OCLintExtractable.java
+++ b/objc-lang/src/main/java/fr/insideapp/sonarqube/objc/issues/oclint/interfaces/OCLintExtractable.java
@@ -1,0 +1,14 @@
+package fr.insideapp.sonarqube.objc.issues.oclint.interfaces;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import fr.insideapp.sonarqube.objc.issues.oclint.models.OCLintReport;
+import org.sonar.api.scanner.ScannerSide;
+
+import java.io.File;
+
+@ScannerSide
+public interface OCLintExtractable {
+
+    OCLintReport extract(File compileCommandsFolder) throws JsonProcessingException, Exception;
+
+}

--- a/objc-lang/src/main/java/fr/insideapp/sonarqube/objc/issues/oclint/interfaces/OCLintExtractable.java
+++ b/objc-lang/src/main/java/fr/insideapp/sonarqube/objc/issues/oclint/interfaces/OCLintExtractable.java
@@ -1,3 +1,20 @@
+/*
+ * SonarQube Apple Plugin - Enables analysis of Swift and Objective-C projects into SonarQube.
+ * Copyright © 2022 inside|app (contact@insideapp.fr)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package fr.insideapp.sonarqube.objc.issues.oclint.interfaces;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/objc-lang/src/main/java/fr/insideapp/sonarqube/objc/issues/oclint/interfaces/OCLintJSONDatabaseBuildable.java
+++ b/objc-lang/src/main/java/fr/insideapp/sonarqube/objc/issues/oclint/interfaces/OCLintJSONDatabaseBuildable.java
@@ -1,3 +1,20 @@
+/*
+ * SonarQube Apple Plugin - Enables analysis of Swift and Objective-C projects into SonarQube.
+ * Copyright © 2022 inside|app (contact@insideapp.fr)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package fr.insideapp.sonarqube.objc.issues.oclint.interfaces;
 
 import org.sonar.api.scanner.ScannerSide;

--- a/objc-lang/src/main/java/fr/insideapp/sonarqube/objc/issues/oclint/interfaces/OCLintJSONDatabaseBuildable.java
+++ b/objc-lang/src/main/java/fr/insideapp/sonarqube/objc/issues/oclint/interfaces/OCLintJSONDatabaseBuildable.java
@@ -1,0 +1,11 @@
+package fr.insideapp.sonarqube.objc.issues.oclint.interfaces;
+
+import org.sonar.api.scanner.ScannerSide;
+
+import java.io.File;
+
+@ScannerSide
+public
+interface OCLintJSONDatabaseBuildable {
+    String build(File jsonCompilationDatabaseFolder);
+}

--- a/objc-lang/src/main/java/fr/insideapp/sonarqube/objc/issues/oclint/interfaces/OCLintReportParsable.java
+++ b/objc-lang/src/main/java/fr/insideapp/sonarqube/objc/issues/oclint/interfaces/OCLintReportParsable.java
@@ -1,3 +1,20 @@
+/*
+ * SonarQube Apple Plugin - Enables analysis of Swift and Objective-C projects into SonarQube.
+ * Copyright © 2022 inside|app (contact@insideapp.fr)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package fr.insideapp.sonarqube.objc.issues.oclint.interfaces;
 
 import fr.insideapp.sonarqube.apple.commons.issues.ReportIssue;

--- a/objc-lang/src/main/java/fr/insideapp/sonarqube/objc/issues/oclint/interfaces/OCLintReportParsable.java
+++ b/objc-lang/src/main/java/fr/insideapp/sonarqube/objc/issues/oclint/interfaces/OCLintReportParsable.java
@@ -1,0 +1,14 @@
+package fr.insideapp.sonarqube.objc.issues.oclint.interfaces;
+
+import fr.insideapp.sonarqube.apple.commons.issues.ReportIssue;
+import fr.insideapp.sonarqube.objc.issues.oclint.models.OCLintReport;
+import org.sonar.api.scanner.ScannerSide;
+
+import java.util.List;
+
+@ScannerSide
+public interface OCLintReportParsable {
+
+    List<ReportIssue> collect(OCLintReport report);
+
+}

--- a/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/helper/ExceptionHelper.java
+++ b/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/helper/ExceptionHelper.java
@@ -1,3 +1,20 @@
+/*
+ * SonarQube Apple Plugin - Enables analysis of Swift and Objective-C projects into SonarQube.
+ * Copyright © 2022 inside|app (contact@insideapp.fr)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package fr.insideapp.sonarqube.objc.helper;
 
 public final class ExceptionHelper {

--- a/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/helper/ExceptionHelper.java
+++ b/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/helper/ExceptionHelper.java
@@ -1,0 +1,18 @@
+package fr.insideapp.sonarqube.objc.helper;
+
+public final class ExceptionHelper {
+
+    private ExceptionHelper() {}
+
+    public static Exception build() {
+        return  new DummyException("My message");
+    }
+
+
+}
+
+class DummyException extends Exception {
+    DummyException(String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/helper/ExtensionProviderTestHelper.java
+++ b/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/helper/ExtensionProviderTestHelper.java
@@ -1,0 +1,23 @@
+package fr.insideapp.sonarqube.objc.helper;
+
+import fr.insideapp.sonarqube.apple.commons.ExtensionProvider;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class ExtensionProviderTestHelper<EP extends ExtensionProvider> {
+
+    protected EP provider;
+    private int expectedExtensionCount;
+
+    protected void setup(EP provider, int expectedExtensionCount)  {
+        this.provider = provider;
+        this.expectedExtensionCount = expectedExtensionCount;
+    }
+
+    @Test
+    public void extensions() {
+        assertThat(provider.extensions()).hasSize(expectedExtensionCount);
+    }
+
+}

--- a/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/helper/ExtensionProviderTestHelper.java
+++ b/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/helper/ExtensionProviderTestHelper.java
@@ -1,3 +1,20 @@
+/*
+ * SonarQube Apple Plugin - Enables analysis of Swift and Objective-C projects into SonarQube.
+ * Copyright © 2022 inside|app (contact@insideapp.fr)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package fr.insideapp.sonarqube.objc.helper;
 
 import fr.insideapp.sonarqube.apple.commons.ExtensionProvider;

--- a/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/issues/oclint/OCLintExtensionProviderTest.java
+++ b/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/issues/oclint/OCLintExtensionProviderTest.java
@@ -1,0 +1,35 @@
+package fr.insideapp.sonarqube.objc.issues.oclint;
+
+import fr.insideapp.sonarqube.objc.helper.ExtensionProviderTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.sonar.api.config.internal.MapSettings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class OCLintExtensionProviderTest extends ExtensionProviderTestHelper<OCLintExtensionProvider> {
+
+    private MapSettings settings;
+
+    @Before
+    public void prepare() {
+        setup(new OCLintExtensionProvider(), 6);
+        settings = new MapSettings();
+    }
+
+    @Test
+    public void jsonCompilationDatabasePath_default() {
+        String jsonCompilationDatabasePath = OCLintExtensionProvider.jsonCompilationDatabasePath(settings.asConfig());
+        assertThat(jsonCompilationDatabasePath).isEqualTo("build/json_compilation_database");
+    }
+
+    @Test
+    public void jsonCompilationDatabasePath_specified() {
+        String expectedCustomPath = "this/is/a/path";
+        settings.setProperty("sonar.apple.jsonCompilationDatabasePath", expectedCustomPath);
+        String jsonCompilationDatabasePath = OCLintExtensionProvider.jsonCompilationDatabasePath(settings.asConfig());
+        assertThat(jsonCompilationDatabasePath).isEqualTo(expectedCustomPath);
+    }
+
+}
+

--- a/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/issues/oclint/OCLintExtensionProviderTest.java
+++ b/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/issues/oclint/OCLintExtensionProviderTest.java
@@ -1,3 +1,20 @@
+/*
+ * SonarQube Apple Plugin - Enables analysis of Swift and Objective-C projects into SonarQube.
+ * Copyright © 2022 inside|app (contact@insideapp.fr)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package fr.insideapp.sonarqube.objc.issues.oclint;
 
 import fr.insideapp.sonarqube.objc.helper.ExtensionProviderTestHelper;

--- a/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/issues/oclint/OCLintExtractorTest.java
+++ b/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/issues/oclint/OCLintExtractorTest.java
@@ -1,3 +1,20 @@
+/*
+ * SonarQube Apple Plugin - Enables analysis of Swift and Objective-C projects into SonarQube.
+ * Copyright © 2022 inside|app (contact@insideapp.fr)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package fr.insideapp.sonarqube.objc.issues.oclint;
 
 import fr.insideapp.sonarqube.objc.issues.oclint.implementations.OCLintExtractor;

--- a/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/issues/oclint/OCLintExtractorTest.java
+++ b/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/issues/oclint/OCLintExtractorTest.java
@@ -1,0 +1,35 @@
+package fr.insideapp.sonarqube.objc.issues.oclint;
+
+import fr.insideapp.sonarqube.objc.issues.oclint.implementations.OCLintExtractor;
+import org.junit.Before;
+import org.junit.Test;
+import org.sonar.api.batch.fs.internal.DefaultFileSystem;
+import org.sonar.api.config.internal.MapSettings;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class OCLintExtractorTest {
+
+    private OCLintExtractor extractor;
+
+    @Before
+    public void prepare() {
+        MapSettings settings = new MapSettings();
+        settings.setProperty("sonar.sources", "folder");
+        DefaultFileSystem fileSystem = new DefaultFileSystem(new File("/oclint/extractor"));
+        extractor = new OCLintExtractor(settings.asConfig(), fileSystem);
+    }
+
+    @Test
+    public void buildSourceArguments() {
+        List<String> arguments = Arrays.asList(extractor.buildSourceArguments());
+        assertThat(arguments).hasSize(2);
+        assertThat(arguments).element(0).isEqualTo("--include");
+        assertThat(arguments).element(1).isEqualTo("/oclint/extractor/folder/.*\\.(h|m|mm)");
+    }
+
+}

--- a/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/issues/oclint/OCLintJSONDatabaseBuilderTest.java
+++ b/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/issues/oclint/OCLintJSONDatabaseBuilderTest.java
@@ -17,6 +17,9 @@
  */
 package fr.insideapp.sonarqube.objc.issues.oclint;
 
+import fr.insideapp.sonarqube.objc.issues.oclint.implementations.OCLintJSONDatabaseBuilder;
+import fr.insideapp.sonarqube.objc.issues.oclint.interfaces.OCLintJSONDatabaseBuildable;
+import org.apache.commons.io.FileUtils;
 import org.json.JSONArray;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,15 +40,15 @@ public class OCLintJSONDatabaseBuilderTest {
         }
     }
 
-    private static final String BASE_DIR = "src/test/resources/oclint/compilation_database";
+    private static final String BASE_DIR = "/oclint/compilation_database";
 
-    private OCLintJSONDatabaseBuilder builder;
+    private OCLintJSONDatabaseBuildable builder;
     private File baseFolder;
 
     @Before
     public void prepare() {
         builder = new OCLintJSONDatabaseBuilder();
-        baseFolder = new File(BASE_DIR);
+        baseFolder = FileUtils.toFile(getClass().getResource(BASE_DIR));
     }
 
     @Test

--- a/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/issues/oclint/OCLintReportParserTest.java
+++ b/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/issues/oclint/OCLintReportParserTest.java
@@ -19,6 +19,8 @@ package fr.insideapp.sonarqube.objc.issues.oclint;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fr.insideapp.sonarqube.apple.commons.issues.ReportIssue;
+import fr.insideapp.sonarqube.objc.issues.oclint.implementations.OCLintReportParser;
+import fr.insideapp.sonarqube.objc.issues.oclint.interfaces.OCLintReportParsable;
 import fr.insideapp.sonarqube.objc.issues.oclint.models.OCLintReport;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
@@ -57,9 +59,9 @@ public class OCLintReportParserTest {
         }
     }
 
-    private static final String BASE_DIR = "src/test/resources/oclint/parser";
+    private static final String BASE_DIR = "/oclint/parser";
 
-    private OCLintReportParser parser;
+    private OCLintReportParsable parser;
     private ObjectMapper objectMapper;
 
     private File baseFolder;
@@ -67,7 +69,7 @@ public class OCLintReportParserTest {
     @Before
     public void prepare() {
         parser = new OCLintReportParser();
-        baseFolder = new File(BASE_DIR);
+        baseFolder = FileUtils.toFile(getClass().getResource(BASE_DIR));
         objectMapper = new ObjectMapper().disable(FAIL_ON_UNKNOWN_PROPERTIES);
     }
 

--- a/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/issues/oclint/OCLintRulesDefinitionTest.java
+++ b/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/issues/oclint/OCLintRulesDefinitionTest.java
@@ -17,6 +17,8 @@
  */
 package fr.insideapp.sonarqube.objc.issues.oclint;
 
+import fr.insideapp.sonarqube.apple.commons.issues.JSONRulesDefinition;
+import org.junit.Before;
 import org.junit.Test;
 import org.sonar.api.server.rule.RulesDefinition;
 
@@ -24,19 +26,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class OCLintRulesDefinitionTest {
 
+    private JSONRulesDefinition rulesDefinition;
+    private RulesDefinition.Context context;
+
+    @Before
+    public void prepare() {
+        rulesDefinition = new OCLintRulesDefinition();
+        context = new RulesDefinition.Context();
+    }
+
     @Test
     public void define() {
-
-        OCLintRulesDefinition rulesDefinition = new OCLintRulesDefinition();
-        RulesDefinition.Context context = new RulesDefinition.Context();
         rulesDefinition.define(context);
 
         RulesDefinition.Repository repository = context.repository("OCLint");
         assertThat(repository).isNotNull();
         assertThat(repository.name()).isEqualTo("OCLint");
         assertThat(repository.language()).isEqualTo("objc");
-        assertThat(repository.rules()).isNotEmpty();
-
-
+        assertThat(repository.rules()).hasSize(72);
     }
 }

--- a/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/ApplePluginTest.java
+++ b/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/ApplePluginTest.java
@@ -39,7 +39,7 @@ public class ApplePluginTest {
         ApplePlugin plugin = new ApplePlugin();
         plugin.define(context);
 
-        assertThat(context.getExtensions()).hasSize(21);
+        assertThat(context.getExtensions()).hasSize(25);
 
 
     }

--- a/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/issues/periphery/PeripherySensor.java
+++ b/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/issues/periphery/PeripherySensor.java
@@ -67,8 +67,8 @@ public class PeripherySensor implements Sensor {
 
         try {
             List<ReportIssue> issues = runAnalysis();
-            ReportIssueRecorder issueRecorder = new ReportIssueRecorder(sensorContext);
-            issueRecorder.recordIssues(issues, PeripheryRulesDefinition.REPOSITORY_KEY);
+            ReportIssueRecorder issueRecorder = new ReportIssueRecorder();
+            issueRecorder.recordIssues(issues, PeripheryRulesDefinition.REPOSITORY_KEY, sensorContext);
         } catch (IOException e) {
             LOGGER.error(e.getMessage(), e);
         }


### PR DESCRIPTION
# Summary

This PR aims to use the dependency injection system of SonarQube, for the sensors (mainly).
The end goal is to follow the standard of SonarQube and also to improve the modularity and testability of the plugin.
The other component of the plugin should also be migrated to use this system, but that can be done later.

# Details

## Registering plugin extensions

In `ApplePlugin`, the `define` began to become quite big. In order to split the registering of the extensions, I've created an interface `ExtensionProvider` that can be adopted by different part of the plugin and allow a simplified registration.
For now, the only implementation is `OCLintExtensionProvider`. 

## Interface over implementation

Until now, the `OCLintSensor` relied directly on implementations.
To improve the modularity and testability, now it relies on interfaces:
- `OCLintExtractable` instead of `OCLintExtractor`
- `OCLintJSONDatabaseBuildable` instead of `OCLintJSONDatabaseBuilder`
- `OCLintReportParsable` instead of `OCLintReportParser`

The implementations are injected in the constructor, by SonarQube. This is why they are annotated with `@ScannerSide` and registered in `OCLintExtensionProvider`.

## Removing `SensorContext` from constructor

According to the documentation, it's a bad implementation if the constructors use `SensorContext` directly. 
Instead, `Configuration` and `FileSystem` should be used.
I've modified some classes in that way.

## Testing

Now that we got a sensor that relies on interfaces it's easier to test it with mock.
I've used Mockito to write tests on `OCLintSensor`.

# DoD

- [x] Implementation
- [x] Unit tests
- [x] Same OCLint issues report on several project as before
- [x] Cleaning of the old implementation & tests