### PR TITLE
Make the OCLintSensor constructor public to fix crash on SonarQube 8.X

### DIFF
--- a/objc-lang/src/main/java/fr/insideapp/sonarqube/objc/issues/oclint/OCLintSensor.java
+++ b/objc-lang/src/main/java/fr/insideapp/sonarqube/objc/issues/oclint/OCLintSensor.java
@@ -48,7 +48,7 @@ public final class OCLintSensor implements Sensor {
     private final ReportIssueRecorder issueRecorder;
 
     private final OCLintReportParsable parser;
-    OCLintSensor(
+    public OCLintSensor(
             final Configuration configuration,
             final FileSystem fileSystem,
             final OCLintJSONDatabaseBuildable builder,


### PR DESCRIPTION
# Summary 

This PR fixes #58.

# DoD

- [x] Implementation
- [x] Unit tests
- [x] No more crashes in SonarQube 8.X
- [x] No new crash in SonarQube 9.X 