### PR TITLE
Fix warnings on generic in unit tests

### DIFF
--- a/commons/src/test/java/fr/insideapp/sonarqube/apple/commons/mapper/AbstractReportMapperTest.java
+++ b/commons/src/test/java/fr/insideapp/sonarqube/apple/commons/mapper/AbstractReportMapperTest.java
@@ -31,9 +31,10 @@ import static org.mockito.Mockito.when;
 
 public final class AbstractReportMapperTest {
 
-    private AbstractReportMapper mapper;
+    private AbstractReportMapper<String, String> mapper;
 
     @Before
+    @SuppressWarnings("unchecked")
     public void prepare() {
         mapper = mock(AbstractReportMapper.class, Mockito.CALLS_REAL_METHODS);
     }


### PR DESCRIPTION
# Summary

- add type in unit tests to remove warning
- add `@SuppressWarnings` to remove warning