### PR TITLE
fix(tests): handling summary test group without any tests

### DIFF
--- a/sonar-apple-plugin/src/main/java/fr/insideapp/sonarqube/apple/xcode/tests/mapper/XcodeTestsMapper.java
+++ b/sonar-apple-plugin/src/main/java/fr/insideapp/sonarqube/apple/xcode/tests/mapper/XcodeTestsMapper.java
@@ -55,10 +55,13 @@ public final class XcodeTestsMapper extends AbstractReportMapper<List<ActionTest
             ImmutablePair<ActionTestSummary, ActionTestGroup> pair = actionTestGroups.pop();
             // keeping a reference to the parent
             ActionTestSummary parent = pair.getKey();
+            List<ActionTestSummaryGroup> summaryGroups = pair.getValue().groups
+                .stream()
+                .filter(summaryGroup -> Objects.nonNull(summaryGroup.tests)) // remove null values
+                .collect(Collectors.toList());
             // we'll loop over each groups of the current group
             // to determine if this is the last "group" level
             // kind of flattening operation, since we can have an infinite level of nesting
-            List<ActionTestSummaryGroup> summaryGroups = pair.getValue().groups;
             summaryGroups.forEach(summaryGroup -> {
                 ActionTest summaryTests = summaryGroup.tests;
                 switch (summaryTests.getType()) {

--- a/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/xcode/tests/XcodeTestsMapperTest.java
+++ b/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/xcode/tests/XcodeTestsMapperTest.java
@@ -62,4 +62,17 @@ public final class XcodeTestsMapperTest {
         assertThat(appleTestSummaries.get(0).groups.get(0).testCases).hasSize(2);
     }
 
+    @Test
+    public void map_none_testSummary() throws IOException {
+        // prepare
+        File actionTestableSummaryFile = new File(baseDir, "testSummary_noTest.json");
+        String actionTestableSummaryJSON = FileUtils.readFileToString(actionTestableSummaryFile, Charset.defaultCharset());
+        ActionTestableSummary actionTestableSummary = objectMapper.readValue(actionTestableSummaryJSON, ActionTestableSummary.class);
+        // test
+        final List<XcodeTestSummary> appleTestSummaries = new ArrayList<>(mapper.map(List.of(actionTestableSummary)));
+        // assert
+        assertThat(appleTestSummaries).hasSize(1);
+        assertThat(appleTestSummaries.get(0).groups).hasSize(0);
+    }
+
 }

--- a/sonar-apple-plugin/src/test/resources/xcode/tests/mapper/testSummary_noTest.json
+++ b/sonar-apple-plugin/src/test/resources/xcode/tests/mapper/testSummary_noTest.json
@@ -1,0 +1,99 @@
+
+{
+    "_type" : {
+        "_name" : "ActionTestableSummary",
+        "_supertype" : {
+            "_name" : "ActionAbstractTestSummary"
+        }
+    },
+    "diagnosticsDirectoryName" : {
+        "_type" : {
+            "_name" : "String"
+        },
+        "_value" : "TestProjectTests-FC7D240B-B238-4442-9937-B1DFEF42DF36-Configuration-Test Scheme Action-Iteration-1"
+    },
+    "identifierURL" : {
+        "_type" : {
+            "_name" : "String"
+        },
+        "_value" : "test:\/\/com.apple.xcode\/TestProject\/TestProjectTests"
+    },
+    "name" : {
+        "_type" : {
+            "_name" : "String"
+        },
+        "_value" : "TestProjectTests"
+    },
+    "projectRelativePath" : {
+        "_type" : {
+            "_name" : "String"
+        },
+        "_value" : "TestProject.xcodeproj"
+    },
+    "targetName" : {
+        "_type" : {
+            "_name" : "String"
+        },
+        "_value" : "TestProjectTests"
+    },
+    "testKind" : {
+        "_type" : {
+            "_name" : "String"
+        },
+        "_value" : "app hosted"
+    },
+    "testLanguage" : {
+        "_type" : {
+            "_name" : "String"
+        },
+        "_value" : ""
+    },
+    "testRegion" : {
+        "_type" : {
+            "_name" : "String"
+        },
+        "_value" : ""
+    },
+    "tests" : {
+        "_type" : {
+            "_name" : "Array"
+        },
+        "_values" : [
+            {
+                "_type" : {
+                    "_name" : "ActionTestSummaryGroup",
+                    "_supertype" : {
+                        "_name" : "ActionTestSummaryIdentifiableObject",
+                        "_supertype" : {
+                            "_name" : "ActionAbstractTestSummary"
+                        }
+                    }
+                },
+                "duration" : {
+                    "_type" : {
+                        "_name" : "Double"
+                    },
+                    "_value" : "0.6080629825592041"
+                },
+                "identifier" : {
+                    "_type" : {
+                        "_name" : "String"
+                    },
+                    "_value" : "All tests"
+                },
+                "identifierURL" : {
+                    "_type" : {
+                        "_name" : "String"
+                    },
+                    "_value" : "test:\/\/com.apple.xcode\/TestProject\/TestProjectTests\/All%20tests"
+                },
+                "name" : {
+                    "_type" : {
+                        "_name" : "String"
+                    },
+                    "_value" : "All tests"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
# Summary 

This PR aims to fix a crash that happens when mapping Xcode summary test group that does not contain any tests. On that case the `subtests` key is not present. Added a filter to remove this edge case.
# DoD

- [x] Implementation
- [x] Unit tests