### PR TITLE
Periphery: handle multi targets and schemes

### DIFF
--- a/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/issues/periphery/runner/PeripheryRunner.java
+++ b/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/issues/periphery/runner/PeripheryRunner.java
@@ -19,6 +19,7 @@ package fr.insideapp.sonarqube.swift.issues.periphery.runner;
 
 import fr.insideapp.sonarqube.apple.commons.ApplePluginExtensionProvider;
 import fr.insideapp.sonarqube.swift.issues.periphery.PeripheryExtensionProvider;
+import org.apache.commons.lang3.StringUtils;
 import org.sonar.api.config.Configuration;
 import org.sonar.api.scanner.ScannerSide;
 
@@ -74,7 +75,7 @@ public final class PeripheryRunner extends PeripheryRunnable {
         List<String> schemes = peripheryExtensionProvider.schemes(configuration);
         if (!schemes.isEmpty()) {
             options.add("--schemes");
-            options.addAll(schemes);
+            options.add(StringUtils.join(schemes, ","));
         }
         return options;
     }
@@ -84,7 +85,7 @@ public final class PeripheryRunner extends PeripheryRunnable {
         List<String> targets = peripheryExtensionProvider.targets(configuration);
         if (!targets.isEmpty()) {
             options.add("--targets");
-            options.addAll(targets);
+            options.add(StringUtils.join(targets, ","));
         }
         return options;
     }

--- a/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/issues/periphery/PeripheryRunnerTest.java
+++ b/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/issues/periphery/PeripheryRunnerTest.java
@@ -127,13 +127,13 @@ public final class PeripheryRunnerTest {
         options.setAccessible(true);
         mockWorkspace(Optional.empty());
         mockProject(Optional.empty());
-        mockSchemes(List.of("MyScheme"));
+        mockSchemes(List.of("MyScheme", "MyOtherScheme"));
         mockTargets(List.of());
         mockIndexStorePath(Optional.empty());
         String[] optionsBuilt = (String[]) options.invoke(runner);
         assertThat(optionsBuilt).isEqualTo(new String[]{
                 "scan",
-                "--schemes", "MyScheme",
+                "--schemes", "MyScheme,MyOtherScheme",
                 "--skip-build",
                 "--format", "json", "--quiet"
         });
@@ -146,12 +146,12 @@ public final class PeripheryRunnerTest {
         mockWorkspace(Optional.empty());
         mockProject(Optional.empty());
         mockSchemes(List.of());
-        mockTargets(List.of("MyTarget"));
+        mockTargets(List.of("MyTarget", "MyOtherTarget"));
         mockIndexStorePath(Optional.empty());
         String[] optionsBuilt = (String[]) options.invoke(runner);
         assertThat(optionsBuilt).isEqualTo(new String[]{
                 "scan",
-                "--targets", "MyTarget",
+                "--targets", "MyTarget,MyOtherTarget",
                 "--skip-build",
                 "--format", "json", "--quiet"
         });


### PR DESCRIPTION
# Summary

This PR aims to update the command line used to run `Periphery`.
Currently the command line generated does not support multi targets and schemes project, because there is a space between the targets or scheme. The correct syntax is a comma between them.

# DoD

- [x] Implementation
- [x] Unit tests