### PR TITLE
Add File Suffixes

### DIFF
--- a/objc-lang/src/main/java/fr/insideapp/sonarqube/objc/ObjectiveC.java
+++ b/objc-lang/src/main/java/fr/insideapp/sonarqube/objc/ObjectiveC.java
@@ -18,17 +18,34 @@
 package fr.insideapp.sonarqube.objc;
 
 import fr.insideapp.sonarqube.apple.commons.tests.LanguageTestFile;
+import org.apache.commons.lang3.StringUtils;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.resources.AbstractLanguage;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public final class ObjectiveC extends AbstractLanguage implements LanguageTestFile {
 
-    public ObjectiveC() {
+    public static final List<String> FILE_SUFFIXES = List.of("h", "m", "mm");
+
+    private Configuration configuration;
+
+    public ObjectiveC(final Configuration configuration) {
         super("objc", "Objective-C");
+        this.configuration = configuration;
     }
 
     @Override
     public String[] getFileSuffixes() {
-        return new String[]{"h", "m", "mm"};
+        final List<String> providedFilesSuffixes = Arrays.asList(configuration.getStringArray(ObjectiveCExtensionProvider.FILE_SUFFIXES_KEY))
+            .stream()
+            .map(String::trim)
+            .filter(StringUtils::isNotBlank)
+            .collect(Collectors.toList());
+        final List<String> filesSuffixes = providedFilesSuffixes.isEmpty() ? FILE_SUFFIXES : providedFilesSuffixes;
+        return filesSuffixes.stream().toArray(String[]::new);
     }
 
     @Override

--- a/objc-lang/src/main/java/fr/insideapp/sonarqube/objc/ObjectiveCExtensionProvider.java
+++ b/objc-lang/src/main/java/fr/insideapp/sonarqube/objc/ObjectiveCExtensionProvider.java
@@ -23,17 +23,34 @@ import fr.insideapp.sonarqube.objc.antlr.ObjectiveCCyclomaticComplexityVisitor;
 import fr.insideapp.sonarqube.objc.antlr.ObjectiveCHighlighterVisitor;
 import fr.insideapp.sonarqube.objc.antlr.ObjectiveCSourceLinesVisitor;
 import fr.insideapp.sonarqube.objc.issues.ObjectiveCProfile;
+import org.sonar.api.config.PropertyDefinition;
+import org.sonar.api.resources.Qualifiers;
 import org.sonar.api.scanner.ScannerSide;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @ScannerSide
 public class ObjectiveCExtensionProvider implements ExtensionProvider {
 
+    public static final String FILE_SUFFIXES_KEY = "sonar.objc.file.suffixes";
+
+    private static final PropertyDefinition FILE_SUFFIXES = PropertyDefinition
+        .builder(FILE_SUFFIXES_KEY)
+        .name("File Suffixes")
+        .description("List of suffixes of Objective-C files to analyze.")
+        .multiValues(true)
+        .category(APPLE_CATEGORY)
+        .subCategory("Objective-C")
+        .onQualifiers(Qualifiers.PROJECT)
+        .defaultValue(ObjectiveC.FILE_SUFFIXES.stream().collect(Collectors.joining(",")))
+        .build();
+
     public List<Object> extensions() {
         return Arrays.asList(
                 ObjectiveC.class,
+            FILE_SUFFIXES,
                 ObjectiveCAntlrContext.class,
                 ObjectiveCSourceLinesVisitor.class,
                 ObjectiveCHighlighterVisitor.class,

--- a/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/ObjectiveCExtensionProviderTest.java
+++ b/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/ObjectiveCExtensionProviderTest.java
@@ -32,7 +32,7 @@ public final class ObjectiveCExtensionProviderTest {
 
     @Test
     public void extensions() {
-        assertThat(provider.extensions()).hasSize(7);
+        assertThat(provider.extensions()).hasSize(8);
     }
 
 }

--- a/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/ObjectiveCSensorTest.java
+++ b/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/ObjectiveCSensorTest.java
@@ -26,20 +26,24 @@ import org.junit.Test;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.config.Configuration;
 
 import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public final class ObjectiveCSensorTest {
 
     private ObjectiveCSensor sensor;
     private SensorContextTester context;
+    private Configuration configuration;
     private ObjectiveC objectiveC;
 
     @Before
     public void prepare() {
-        objectiveC = new ObjectiveC();
+        configuration = mock(Configuration.class);
+        objectiveC = new ObjectiveC(configuration);
         context = SensorContextTester.create(new File("."));
         sensor = new ObjectiveCSensor(
                 objectiveC,

--- a/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/ObjectiveCTest.java
+++ b/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/ObjectiveCTest.java
@@ -19,24 +19,66 @@ package fr.insideapp.sonarqube.objc;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.resources.Language;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public final class ObjectiveCTest {
 
     private Language language;
+    private Configuration configuration;
 
     @Before
     public void prepare() {
-        language = new ObjectiveC();
+        configuration = mock(Configuration.class);
+        language = new ObjectiveC(configuration);
     }
 
     @Test
-    public void definition() {
-        assertThat(language.getKey()).isEqualTo("objc");
-        assertThat(language.getName()).isEqualTo("Objective-C");
-        assertThat(language.getFileSuffixes()).containsOnly("h", "m", "mm");
+    public void fileSuffixes_default() {
+        // prepare
+        when(configuration.getStringArray(ObjectiveCExtensionProvider.FILE_SUFFIXES_KEY))
+            .thenReturn(new String[]{});
+        // test
+        final String[] fileSuffixes = language.getFileSuffixes();
+        // prepare
+        assertThat(fileSuffixes).containsAll(ObjectiveC.FILE_SUFFIXES);
+    }
+
+    @Test
+    public void fileSuffixes_custom() {
+        // prepare
+        when(configuration.getStringArray(ObjectiveCExtensionProvider.FILE_SUFFIXES_KEY))
+            .thenReturn(new String[]{"foo", "bar"});
+        // test
+        final String[] fileSuffixes = language.getFileSuffixes();
+        // prepare
+        assertThat(fileSuffixes).containsExactlyInAnyOrder("foo", "bar");
+    }
+
+    @Test
+    public void fileSuffixes_custom_but_not_good() {
+        // prepare
+        when(configuration.getStringArray(ObjectiveCExtensionProvider.FILE_SUFFIXES_KEY))
+            .thenReturn(new String[]{"", "  "});
+        // test
+        final String[] fileSuffixes = language.getFileSuffixes();
+        // prepare
+        assertThat(fileSuffixes).containsAll(ObjectiveC.FILE_SUFFIXES);
+    }
+
+    @Test
+    public void fileSuffixes_custom_with_spaces() {
+        // prepare
+        when(configuration.getStringArray(ObjectiveCExtensionProvider.FILE_SUFFIXES_KEY))
+            .thenReturn(new String[]{"foo  ", "  bar", "", "  "});
+        // test
+        final String[] fileSuffixes = language.getFileSuffixes();
+        // prepare
+        assertThat(fileSuffixes).containsExactlyInAnyOrder("foo", "bar");
     }
 
 }

--- a/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/antlr/ObjectiveCCyclomaticComplexityVisitorTest.java
+++ b/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/antlr/ObjectiveCCyclomaticComplexityVisitorTest.java
@@ -26,6 +26,7 @@ import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.batch.sensor.measure.Measure;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.measures.CoreMetrics;
 
 import java.io.File;
@@ -34,6 +35,7 @@ import java.nio.charset.Charset;
 import java.nio.file.Paths;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class ObjectiveCCyclomaticComplexityVisitorTest {
 
@@ -49,6 +51,8 @@ public class ObjectiveCCyclomaticComplexityVisitorTest {
 
     private static final String BASE_DIR = "src/test/resources/objc/cyclomatic_complexity";
     private SensorContextTester sensorContext;
+    private Configuration configuration;
+
     private ObjectiveC objectiveC;
     private ObjectiveCAntlrContext antlrContext;
     private CustomTreeVisitor customTreeVisitor;
@@ -56,7 +60,8 @@ public class ObjectiveCCyclomaticComplexityVisitorTest {
     @Before
     public void prepare() {
         sensorContext = SensorContextTester.create(new File(BASE_DIR));
-        objectiveC = new ObjectiveC();
+        configuration = mock(Configuration.class);
+        objectiveC = new ObjectiveC(configuration);
         antlrContext = new ObjectiveCAntlrContext();
         customTreeVisitor = new CustomTreeVisitor(new ObjectiveCCyclomaticComplexityVisitor());
     }

--- a/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/antlr/ObjectiveCSourceLinesVisitorTest.java
+++ b/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/antlr/ObjectiveCSourceLinesVisitorTest.java
@@ -25,6 +25,7 @@ import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.batch.sensor.measure.Measure;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.measures.CoreMetrics;
 
 import java.io.File;
@@ -33,6 +34,7 @@ import java.nio.charset.Charset;
 import java.nio.file.Paths;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class ObjectiveCSourceLinesVisitorTest {
 
@@ -51,6 +53,9 @@ public class ObjectiveCSourceLinesVisitorTest {
 
     private static final String BASE_DIR = "src/test/resources/objc/source_lines_visitor";
     private SensorContextTester sensorContext;
+
+    private Configuration configuration;
+
     private ObjectiveC objectiveC;
     private ObjectiveCAntlrContext antlrContext;
     private ObjectiveCSourceLinesVisitor visitor;
@@ -58,46 +63,44 @@ public class ObjectiveCSourceLinesVisitorTest {
     @Before
     public void prepare() {
         sensorContext = SensorContextTester.create(new File(BASE_DIR));
-        objectiveC = new ObjectiveC();
+        configuration = mock(Configuration.class);
+        objectiveC = new ObjectiveC(configuration);
         antlrContext = new ObjectiveCAntlrContext();
         visitor = new ObjectiveCSourceLinesVisitor();
     }
 
     @Test
     public void testNoComment() throws IOException {
-        assertContainer(new Container("NoComment", 7, 0));
+        assertContainer(new Container("NoComment.m", 7, 0));
     }
 
     @Test
     public void testNoCode() throws IOException {
-        assertContainer(new Container("NoCode", 0, 1));
+        assertContainer(new Container("NoCode.m", 0, 1));
     }
 
     @Test
     public void testEmpty() throws IOException {
-        assertContainer(new Container("Empty", 0, 0));
+        assertContainer(new Container("Empty.m", 0, 0));
     }
 
     @Test
     public void testLineWithMixedCodeComment() throws IOException {
-        assertContainer(new Container("LineWithMixedCodeComment", 3, 0));
+        assertContainer(new Container("LineWithMixedCodeComment.m", 3, 0));
     }
 
     @Test
     public void testWhiteLineIgnored() throws IOException {
-        assertContainer(new Container("WhiteLineIgnored", 7, 1));
+        assertContainer(new Container("WhiteLineIgnored.m", 7, 1));
     }
 
     private void assertContainer(Container container) throws IOException {
-
-        final String completeFileName = container.fileName + ".m";
-
         // Real file
-        File file = new File(BASE_DIR, completeFileName);
+        File file = new File(BASE_DIR, container.fileName);
 
         // Mock file for test purpose
         // Setting it up with the real file properties
-        InputFile inputFile = new TestInputFileBuilder("", completeFileName)
+        InputFile inputFile = new TestInputFileBuilder("", container.fileName)
                 .setLanguage(objectiveC.getKey())
                 .setModuleBaseDir(Paths.get(BASE_DIR))
                 .setContents(FileUtils.readFileToString(file, Charset.defaultCharset()))

--- a/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/issues/ObjectiveCProfileTest.java
+++ b/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/issues/ObjectiveCProfileTest.java
@@ -24,12 +24,15 @@ import fr.insideapp.sonarqube.objc.issues.oclint.OCLintRulesDefinition;
 import fr.insideapp.sonarqube.objc.issues.warnings.XcodeWarningObjectiveCRulesDefinition;
 import org.junit.Before;
 import org.junit.Test;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public final class ObjectiveCProfileTest {
 
+    private Configuration configuration;
     private ObjectiveC objectiveC;
 
     private ObjectiveCProfile profile;
@@ -38,7 +41,8 @@ public final class ObjectiveCProfileTest {
 
     @Before
     public void prepare() {
-        objectiveC = new ObjectiveC();
+        configuration = mock(Configuration.class);
+        objectiveC = new ObjectiveC(configuration);
         context = new BuiltInQualityProfilesDefinition.Context();
         profile = new ObjectiveCProfile(
                 objectiveC,

--- a/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/issues/mobsfscan/MobSFScanObjectiveCRulesDefinitionTest.java
+++ b/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/issues/mobsfscan/MobSFScanObjectiveCRulesDefinitionTest.java
@@ -21,19 +21,23 @@ import fr.insideapp.sonarqube.apple.commons.rules.MobSFScanRulesDefinition;
 import fr.insideapp.sonarqube.objc.ObjectiveC;
 import org.junit.Before;
 import org.junit.Test;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.server.rule.RulesDefinition;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public final class MobSFScanObjectiveCRulesDefinitionTest {
 
     private MobSFScanRulesDefinition rulesDefinition;
+    private Configuration configuration;
     private ObjectiveC language;
     private RulesDefinition.Context context;
 
     @Before
     public void prepare() {
-        language = new ObjectiveC();
+        configuration = mock(Configuration.class);
+        language = new ObjectiveC(configuration);
         rulesDefinition = new MobSFScanObjectiveCRulesDefinition(language);
         context = new RulesDefinition.Context();
     }

--- a/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/issues/oclint/OCLintRulesDefinitionTest.java
+++ b/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/issues/oclint/OCLintRulesDefinitionTest.java
@@ -21,19 +21,23 @@ import fr.insideapp.sonarqube.apple.commons.rules.JSONRulesDefinition;
 import fr.insideapp.sonarqube.objc.ObjectiveC;
 import org.junit.Before;
 import org.junit.Test;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.server.rule.RulesDefinition;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public final class OCLintRulesDefinitionTest {
 
     private JSONRulesDefinition rulesDefinition;
+    private Configuration configuration;
     private ObjectiveC language;
     private RulesDefinition.Context context;
 
     @Before
     public void prepare() {
-        language = new ObjectiveC();
+        configuration = mock(Configuration.class);
+        language = new ObjectiveC(configuration);
         rulesDefinition = new OCLintRulesDefinition(language);
         context = new RulesDefinition.Context();
     }

--- a/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/issues/oclint/OCLintRunnerTest.java
+++ b/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/issues/oclint/OCLintRunnerTest.java
@@ -19,11 +19,13 @@ package fr.insideapp.sonarqube.objc.issues.oclint;
 
 import fr.insideapp.sonarqube.apple.commons.SonarProjectConfiguration;
 import fr.insideapp.sonarqube.objc.ObjectiveC;
+import fr.insideapp.sonarqube.objc.ObjectiveCExtensionProvider;
 import fr.insideapp.sonarqube.objc.issues.oclint.runner.OCLintRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.fs.internal.DefaultFileSystem;
+import org.sonar.api.config.Configuration;
 
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
@@ -38,6 +40,7 @@ public final class OCLintRunnerTest {
 
     private static final String BASE_DIR = "/oclint/runner";
 
+    private Configuration configuration;
     private OCLintRunner runner;
     private SonarProjectConfiguration sonarProjectConfiguration;
     private OCLintExtensionProvider ocLintExtensionProvider;
@@ -50,7 +53,8 @@ public final class OCLintRunnerTest {
         sonarProjectConfiguration = mock(SonarProjectConfiguration.class);
         ocLintExtensionProvider = mock(OCLintExtensionProvider.class);
         fileSystem = new DefaultFileSystem(new File(BASE_DIR));
-        runner = new OCLintRunner(sonarProjectConfiguration, ocLintExtensionProvider, new ObjectiveC(), fileSystem);
+        configuration = mock(Configuration.class);
+        runner = new OCLintRunner(sonarProjectConfiguration, ocLintExtensionProvider, new ObjectiveC(configuration), fileSystem);
         clazz = runner.getClass();
     }
 
@@ -60,6 +64,8 @@ public final class OCLintRunnerTest {
         options.setAccessible(true);
         mockSources(List.of());
         mockJSONCompilationDatabase(new File("/a/path/to","database.json"));
+        when(configuration.getStringArray(ObjectiveCExtensionProvider.FILE_SUFFIXES_KEY))
+            .thenReturn(ObjectiveC.FILE_SUFFIXES.stream().toArray(String[]::new));
         String[] optionsBuilt = (String[]) options.invoke(runner);
         assertThat(optionsBuilt).isEqualTo(new String[]{
                 "-p", "/a/path/to",
@@ -74,6 +80,8 @@ public final class OCLintRunnerTest {
         options.setAccessible(true);
         mockSources(List.of("source"));
         mockJSONCompilationDatabase(new File("/a/path/to","database.json"));
+        when(configuration.getStringArray(ObjectiveCExtensionProvider.FILE_SUFFIXES_KEY))
+            .thenReturn(ObjectiveC.FILE_SUFFIXES.stream().toArray(String[]::new));
         String[] optionsBuilt = (String[]) options.invoke(runner);
         assertThat(optionsBuilt).isEqualTo(new String[]{
                 "--include", "/oclint/runner/source/.*\\.(h|m|mm)",
@@ -89,6 +97,8 @@ public final class OCLintRunnerTest {
         options.setAccessible(true);
         mockSources(List.of("source1", "source2"));
         mockJSONCompilationDatabase(new File("/a/path/to","database.json"));
+        when(configuration.getStringArray(ObjectiveCExtensionProvider.FILE_SUFFIXES_KEY))
+            .thenReturn(ObjectiveC.FILE_SUFFIXES.stream().toArray(String[]::new));
         String[] optionsBuilt = (String[]) options.invoke(runner);
         assertThat(optionsBuilt).isEqualTo(new String[]{
                 "--include", "/oclint/runner/source1/.*\\.(h|m|mm)",

--- a/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/issues/oclint/OCLintSensorTest.java
+++ b/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/issues/oclint/OCLintSensorTest.java
@@ -36,6 +36,7 @@ import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.batch.sensor.issue.Issue;
+import org.sonar.api.config.Configuration;
 
 import java.io.File;
 import java.nio.file.Paths;
@@ -53,6 +54,7 @@ public class OCLintSensorTest {
     private final File baseDir = FileUtils.toFile(getClass().getResource(BASE_DIR));
 
     private SensorContextTester context;
+    private Configuration configuration;
     private ObjectiveC objectiveC;
     private OCLintJSONCompilationDatabaseFolderRetrievable retriever;
     private OCLintJSONCompilationDatabaseBuildable builder;
@@ -73,7 +75,8 @@ public class OCLintSensorTest {
         mapper = mock(OCLintReportMappable.class);
         rulesDefinition = mock(OCLintRulesDefinition.class);
         context = SensorContextTester.create(baseDir);
-        objectiveC = new ObjectiveC();
+        configuration = mock(Configuration.class);
+        objectiveC = new ObjectiveC(configuration);
         sensor = new OCLintSensor(objectiveC,
                 retriever, builder, writer,
                 runner, parser, mapper,

--- a/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/issues/warnings/XcodeWarningObjectiveCRulesDefinitionTest.java
+++ b/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/issues/warnings/XcodeWarningObjectiveCRulesDefinitionTest.java
@@ -21,19 +21,23 @@ import fr.insideapp.sonarqube.apple.commons.rules.JSONRulesDefinition;
 import fr.insideapp.sonarqube.objc.ObjectiveC;
 import org.junit.Before;
 import org.junit.Test;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.server.rule.RulesDefinition;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class XcodeWarningObjectiveCRulesDefinitionTest {
 
     private JSONRulesDefinition rulesDefinition;
+    private Configuration configuration;
     private ObjectiveC language;
     private RulesDefinition.Context context;
 
     @Before
     public void prepare() {
-        language = new ObjectiveC();
+        configuration = mock(Configuration.class);
+        language = new ObjectiveC(configuration);
         rulesDefinition = new XcodeWarningObjectiveCRulesDefinition(language);
         context = new RulesDefinition.Context();
     }

--- a/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/tests/ObjectiveCLanguageTestFileFinderTest.java
+++ b/objc-lang/src/test/java/fr/insideapp/sonarqube/objc/tests/ObjectiveCLanguageTestFileFinderTest.java
@@ -25,10 +25,12 @@ import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.internal.DefaultFileSystem;
 import org.sonar.api.batch.fs.internal.DefaultInputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
+import org.sonar.api.config.Configuration;
 
 import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public final class ObjectiveCLanguageTestFileFinderTest {
 
@@ -37,12 +39,14 @@ public final class ObjectiveCLanguageTestFileFinderTest {
 
     private ObjectiveCLanguageTestFileFinder fileFinder;
     private DefaultFileSystem fileSystem;
+    private Configuration configuration;
 
     private ObjectiveC objectiveC;
 
     @Before
     public void prepare() {
-        objectiveC = new ObjectiveC();
+        configuration = mock(Configuration.class);
+        objectiveC = new ObjectiveC(configuration);
         fileFinder = new ObjectiveCLanguageTestFileFinder(objectiveC);
         fileSystem = new DefaultFileSystem(baseDir);
     }

--- a/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/ApplePluginTest.java
+++ b/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/ApplePluginTest.java
@@ -40,6 +40,6 @@ public class ApplePluginTest {
         plugin.define(context);
 
         List<?> extensions = context.getExtensions();
-        assertThat(extensions).hasSize(77);
+        assertThat(extensions).hasSize(78);
     }
 }

--- a/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/ApplePluginTest.java
+++ b/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/ApplePluginTest.java
@@ -40,6 +40,6 @@ public class ApplePluginTest {
         plugin.define(context);
 
         List<?> extensions = context.getExtensions();
-        assertThat(extensions).hasSize(78);
+        assertThat(extensions).hasSize(79);
     }
 }

--- a/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/mobsfscan/MobSFScanReportIssueSplitterTest.java
+++ b/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/mobsfscan/MobSFScanReportIssueSplitterTest.java
@@ -21,6 +21,7 @@ import fr.insideapp.sonarqube.apple.commons.rules.MobSFScanRulesDefinition;
 import fr.insideapp.sonarqube.apple.commons.issues.ReportIssue;
 import fr.insideapp.sonarqube.apple.mobsfscan.splitter.MobSFScanReportIssueSplitter;
 import fr.insideapp.sonarqube.objc.ObjectiveC;
+import fr.insideapp.sonarqube.objc.ObjectiveCExtensionProvider;
 import fr.insideapp.sonarqube.swift.Swift;
 import fr.insideapp.sonarqube.swift.SwiftExtensionProvider;
 import org.junit.Before;
@@ -58,7 +59,7 @@ public final class MobSFScanReportIssueSplitterTest {
     public void prepare() {
         configuration = mock(Configuration.class);
         swift = new Swift(configuration);
-        objc = new ObjectiveC();
+        objc = new ObjectiveC(configuration);
         swiftRulesDefinition = new MobSFScanRulesDefinition(swift) {};
         objcRulesDefinition = new MobSFScanRulesDefinition(objc) {};
         ActiveRulesBuilder builder = new ActiveRulesBuilder();
@@ -106,6 +107,8 @@ public final class MobSFScanReportIssueSplitterTest {
         ReportIssue reportIssue = new ReportIssue(buildRule(swiftRulesDefinition.getLanguage()), "message", "path/to/file.ext", 15);
         when(configuration.getStringArray(SwiftExtensionProvider.FILE_SUFFIXES_KEY))
             .thenReturn(Swift.FILE_SUFFIXES.stream().toArray(String[]::new));
+        when(configuration.getStringArray(ObjectiveCExtensionProvider.FILE_SUFFIXES_KEY))
+            .thenReturn(ObjectiveC.FILE_SUFFIXES.stream().toArray(String[]::new));
         // test
         Map<MobSFScanRulesDefinition, List<ReportIssue>> issuesSplit = splitter.split(List.of(reportIssue), activeRules);
         // assert
@@ -135,6 +138,8 @@ public final class MobSFScanReportIssueSplitterTest {
         when(configuration.getStringArray(SwiftExtensionProvider.FILE_SUFFIXES_KEY))
             .thenReturn(Swift.FILE_SUFFIXES.stream().toArray(String[]::new));
         ReportIssue reportIssue2 = new ReportIssue(buildRule(objcRulesDefinition.getLanguage()), "message", "path/to/file.m", 15);
+        when(configuration.getStringArray(ObjectiveCExtensionProvider.FILE_SUFFIXES_KEY))
+            .thenReturn(ObjectiveC.FILE_SUFFIXES.stream().toArray(String[]::new));
         // test
         Map<MobSFScanRulesDefinition, List<ReportIssue>> issuesSplit = splitter.split(List.of(reportIssue1, reportIssue2), activeRules);
         // assert

--- a/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/mobsfscan/MobSFScanReportIssueSplitterTest.java
+++ b/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/mobsfscan/MobSFScanReportIssueSplitterTest.java
@@ -22,11 +22,13 @@ import fr.insideapp.sonarqube.apple.commons.issues.ReportIssue;
 import fr.insideapp.sonarqube.apple.mobsfscan.splitter.MobSFScanReportIssueSplitter;
 import fr.insideapp.sonarqube.objc.ObjectiveC;
 import fr.insideapp.sonarqube.swift.Swift;
+import fr.insideapp.sonarqube.swift.SwiftExtensionProvider;
 import org.junit.Before;
 import org.junit.Test;
 import org.sonar.api.batch.rule.ActiveRules;
 import org.sonar.api.batch.rule.internal.ActiveRulesBuilder;
 import org.sonar.api.batch.rule.internal.NewActiveRule;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.resources.Language;
 import org.sonar.api.rule.RuleKey;
 
@@ -35,9 +37,12 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public final class MobSFScanReportIssueSplitterTest {
 
+    private Configuration configuration;
     private MobSFScanReportIssueSplitter splitter;
 
     private ActiveRules activeRules;
@@ -51,7 +56,8 @@ public final class MobSFScanReportIssueSplitterTest {
 
     @Before
     public void prepare() {
-        swift = new Swift();
+        configuration = mock(Configuration.class);
+        swift = new Swift(configuration);
         objc = new ObjectiveC();
         swiftRulesDefinition = new MobSFScanRulesDefinition(swift) {};
         objcRulesDefinition = new MobSFScanRulesDefinition(objc) {};
@@ -98,6 +104,8 @@ public final class MobSFScanReportIssueSplitterTest {
     public void one_issue_file_path_wrong_extension() {
         // prepare
         ReportIssue reportIssue = new ReportIssue(buildRule(swiftRulesDefinition.getLanguage()), "message", "path/to/file.ext", 15);
+        when(configuration.getStringArray(SwiftExtensionProvider.FILE_SUFFIXES_KEY))
+            .thenReturn(Swift.FILE_SUFFIXES.stream().toArray(String[]::new));
         // test
         Map<MobSFScanRulesDefinition, List<ReportIssue>> issuesSplit = splitter.split(List.of(reportIssue), activeRules);
         // assert
@@ -110,6 +118,8 @@ public final class MobSFScanReportIssueSplitterTest {
     public void one_issue_file_path_valid_extension() {
         // prepare
         ReportIssue reportIssue = new ReportIssue(buildRule(swiftRulesDefinition.getLanguage()), "message", "path/to/file.swift", 15);
+        when(configuration.getStringArray(SwiftExtensionProvider.FILE_SUFFIXES_KEY))
+            .thenReturn(Swift.FILE_SUFFIXES.stream().toArray(String[]::new));
         // test
         Map<MobSFScanRulesDefinition, List<ReportIssue>> issuesSplit = splitter.split(List.of(reportIssue), activeRules);
         // assert
@@ -122,6 +132,8 @@ public final class MobSFScanReportIssueSplitterTest {
     public void two_issue_file_path_valid_extension() {
         // prepare
         ReportIssue reportIssue1 = new ReportIssue(buildRule(swiftRulesDefinition.getLanguage()), "message", "path/to/file.swift", 15);
+        when(configuration.getStringArray(SwiftExtensionProvider.FILE_SUFFIXES_KEY))
+            .thenReturn(Swift.FILE_SUFFIXES.stream().toArray(String[]::new));
         ReportIssue reportIssue2 = new ReportIssue(buildRule(objcRulesDefinition.getLanguage()), "message", "path/to/file.m", 15);
         // test
         Map<MobSFScanRulesDefinition, List<ReportIssue>> issuesSplit = splitter.split(List.of(reportIssue1, reportIssue2), activeRules);

--- a/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/mobsfscan/MobSFScanSensorTest.java
+++ b/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/mobsfscan/MobSFScanSensorTest.java
@@ -74,7 +74,7 @@ public final class MobSFScanSensorTest {
         rulesDefinition = mock(MobSFScanRulesDefinition.class);
         configuration = mock(Configuration.class);
         swift = new Swift(configuration);
-        objectiveC = new ObjectiveC();
+        objectiveC = new ObjectiveC(configuration);
         sensor = new MobSFScanSensor(
                 swift,
                 objectiveC,

--- a/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/mobsfscan/MobSFScanSensorTest.java
+++ b/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/mobsfscan/MobSFScanSensorTest.java
@@ -34,6 +34,7 @@ import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.batch.sensor.issue.Issue;
+import org.sonar.api.config.Configuration;
 
 import java.io.File;
 import java.nio.file.Paths;
@@ -51,6 +52,8 @@ public final class MobSFScanSensorTest {
     private final File baseDir = FileUtils.toFile(getClass().getResource(BASE_DIR));
 
     private MobSFScanSensor sensor;
+    private Configuration configuration;
+
     private Swift swift;
     private ObjectiveC objectiveC;
     private SensorContextTester context;
@@ -69,7 +72,8 @@ public final class MobSFScanSensorTest {
         mapper = mock(MobSFScanReportMappable.class);
         splitter = mock(MobSFScanReportIssueSplittable.class);
         rulesDefinition = mock(MobSFScanRulesDefinition.class);
-        swift = new Swift();
+        configuration = mock(Configuration.class);
+        swift = new Swift(configuration);
         objectiveC = new ObjectiveC();
         sensor = new MobSFScanSensor(
                 swift,

--- a/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/xcode/coverage/XcodeCoverageSensorTest.java
+++ b/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/xcode/coverage/XcodeCoverageSensorTest.java
@@ -102,7 +102,7 @@ public class XcodeCoverageSensorTest {
         context = SensorContextTester.create(baseDir);
         configuration = mock(Configuration.class);
         swift = new Swift(configuration);
-        objectiveC = new ObjectiveC();
+        objectiveC = new ObjectiveC(configuration);
         runner = mock(XcodeCoverageReadRunnable.class);
         sensor = new XcodeCoverageSensor(
                 swift,

--- a/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/xcode/coverage/XcodeCoverageSensorTest.java
+++ b/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/xcode/coverage/XcodeCoverageSensorTest.java
@@ -32,6 +32,7 @@ import org.sonar.api.batch.fs.internal.DefaultInputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.config.Configuration;
 
 import java.io.File;
 import java.io.IOException;
@@ -89,6 +90,8 @@ public class XcodeCoverageSensorTest {
     private final File baseDir = FileUtils.toFile(getClass().getResource(BASE_DIR));
 
     private XcodeCoverageSensor sensor;
+    private Configuration configuration;
+
     private Swift swift;
     private ObjectiveC objectiveC;
     private XcodeCoverageReadRunnable runner;
@@ -97,7 +100,8 @@ public class XcodeCoverageSensorTest {
     @Before
     public void prepare() {
         context = SensorContextTester.create(baseDir);
-        swift = new Swift();
+        configuration = mock(Configuration.class);
+        swift = new Swift(configuration);
         objectiveC = new ObjectiveC();
         runner = mock(XcodeCoverageReadRunnable.class);
         sensor = new XcodeCoverageSensor(

--- a/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/xcode/tests/XcodeTestsSensorTest.java
+++ b/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/xcode/tests/XcodeTestsSensorTest.java
@@ -100,7 +100,7 @@ public class XcodeTestsSensorTest {
         context = SensorContextTester.create(baseDir);
         configuration = mock(Configuration.class);
         swift = new Swift(configuration);
-        objectiveC = new ObjectiveC();
+        objectiveC = new ObjectiveC(configuration);
         resultRunner = mock(XcodeResultReadRunnable.class);
         resultObjectRunner = mock(XcodeResultReadObjectRunnable.class);
         sensor = new XcodeTestsSensor(

--- a/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/xcode/tests/XcodeTestsSensorTest.java
+++ b/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/xcode/tests/XcodeTestsSensorTest.java
@@ -35,6 +35,7 @@ import org.sonar.api.batch.fs.internal.DefaultInputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.measures.CoreMetrics;
 
 import java.io.File;
@@ -81,6 +82,7 @@ public class XcodeTestsSensorTest {
     private static final String EXTENSION = "ext";
 
     private XcodeTestsSensor sensor;
+    private Configuration configuration;
     private Swift swift;
     private ObjectiveC objectiveC;
     private SensorContextTester context;
@@ -96,7 +98,8 @@ public class XcodeTestsSensorTest {
         };
         XcodeTestFileFinder testFileFinder = new XcodeTestFileFinder(fileFinders);
         context = SensorContextTester.create(baseDir);
-        swift = new Swift();
+        configuration = mock(Configuration.class);
+        swift = new Swift(configuration);
         objectiveC = new ObjectiveC();
         resultRunner = mock(XcodeResultReadRunnable.class);
         resultObjectRunner = mock(XcodeResultReadObjectRunnable.class);

--- a/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/xcode/warnings/XcodeWarningsSensorTest.java
+++ b/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/xcode/warnings/XcodeWarningsSensorTest.java
@@ -73,7 +73,7 @@ public final class XcodeWarningsSensorTest {
         context = SensorContextTester.create(baseDir);
         configuration = mock(Configuration.class);
         swift = new Swift(configuration);
-        objectiveC = new ObjectiveC();
+        objectiveC = new ObjectiveC(configuration);
         runner = mock(XcodeResultReadRunnable.class);
         parser = mock(XcodeWarningParsable.class);
         converter = mock(XcodeWarningConvertible.class);

--- a/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/xcode/warnings/XcodeWarningsSensorTest.java
+++ b/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/xcode/warnings/XcodeWarningsSensorTest.java
@@ -35,6 +35,7 @@ import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.batch.sensor.issue.Issue;
+import org.sonar.api.config.Configuration;
 
 import java.io.File;
 import java.io.IOException;
@@ -56,6 +57,7 @@ public final class XcodeWarningsSensorTest {
     private final File baseDir = FileUtils.toFile(getClass().getResource(BASE_DIR));
 
     private XcodeWarningsSensor sensor;
+    private Configuration configuration;
     private Swift swift;
     private ObjectiveC objectiveC;
     private SensorContextTester context;
@@ -69,7 +71,8 @@ public final class XcodeWarningsSensorTest {
     @Before
     public void prepare() {
         context = SensorContextTester.create(baseDir);
-        swift = new Swift();
+        configuration = mock(Configuration.class);
+        swift = new Swift(configuration);
         objectiveC = new ObjectiveC();
         runner = mock(XcodeResultReadRunnable.class);
         parser = mock(XcodeWarningParsable.class);

--- a/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/xcode/warnings/splitter/XcodeWarningsReportIssueSplitterTest.java
+++ b/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/xcode/warnings/splitter/XcodeWarningsReportIssueSplitterTest.java
@@ -21,11 +21,13 @@ import fr.insideapp.sonarqube.apple.commons.issues.ReportIssue;
 import fr.insideapp.sonarqube.apple.commons.warnings.XcodeWarningRulesDefinition;
 import fr.insideapp.sonarqube.objc.ObjectiveC;
 import fr.insideapp.sonarqube.swift.Swift;
+import fr.insideapp.sonarqube.swift.SwiftExtensionProvider;
 import org.junit.Before;
 import org.junit.Test;
 import org.sonar.api.batch.rule.ActiveRules;
 import org.sonar.api.batch.rule.internal.ActiveRulesBuilder;
 import org.sonar.api.batch.rule.internal.NewActiveRule;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.resources.Language;
 import org.sonar.api.rule.RuleKey;
 
@@ -34,9 +36,12 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public final class XcodeWarningsReportIssueSplitterTest {
 
+    private Configuration configuration;
     private XcodeWarningsReportIssueSplitter splitter;
 
     private ActiveRules activeRules;
@@ -50,7 +55,8 @@ public final class XcodeWarningsReportIssueSplitterTest {
 
     @Before
     public void prepare() {
-        swift = new Swift();
+        configuration = mock(Configuration.class);
+        swift = new Swift(configuration);
         objc = new ObjectiveC();
         swiftRulesDefinition = new XcodeWarningRulesDefinition(swift) {};
         objcRulesDefinition = new XcodeWarningRulesDefinition(objc) {};
@@ -85,6 +91,8 @@ public final class XcodeWarningsReportIssueSplitterTest {
     public void one_issue_file_path_wrong_extension() {
         // prepare
         ReportIssue reportIssue = new ReportIssue(buildRule(swiftRulesDefinition.getLanguage()), "message", "path/to/file.ext", 15);
+        when(configuration.getStringArray(SwiftExtensionProvider.FILE_SUFFIXES_KEY))
+            .thenReturn(Swift.FILE_SUFFIXES.stream().toArray(String[]::new));
         // test
         Map<XcodeWarningRulesDefinition, List<ReportIssue>> issuesSplit = splitter.split(List.of(reportIssue), activeRules);
         // assert
@@ -97,6 +105,8 @@ public final class XcodeWarningsReportIssueSplitterTest {
     public void one_issue_file_path_valid_extension() {
         // prepare
         ReportIssue reportIssue = new ReportIssue(buildRule(swiftRulesDefinition.getLanguage()), "message", "path/to/file.swift", 15);
+        when(configuration.getStringArray(SwiftExtensionProvider.FILE_SUFFIXES_KEY))
+            .thenReturn(Swift.FILE_SUFFIXES.stream().toArray(String[]::new));
         // test
         Map<XcodeWarningRulesDefinition, List<ReportIssue>> issuesSplit = splitter.split(List.of(reportIssue), activeRules);
         // assert
@@ -109,6 +119,8 @@ public final class XcodeWarningsReportIssueSplitterTest {
     public void two_issue_file_path_valid_extension() {
         // prepare
         ReportIssue reportIssue1 = new ReportIssue(buildRule(swiftRulesDefinition.getLanguage()), "message", "path/to/file.swift", 15);
+        when(configuration.getStringArray(SwiftExtensionProvider.FILE_SUFFIXES_KEY))
+            .thenReturn(Swift.FILE_SUFFIXES.stream().toArray(String[]::new));
         ReportIssue reportIssue2 = new ReportIssue(buildRule(objcRulesDefinition.getLanguage()), "message", "path/to/file.m", 15);
         // test
         Map<XcodeWarningRulesDefinition, List<ReportIssue>> issuesSplit = splitter.split(List.of(reportIssue1, reportIssue2), activeRules);

--- a/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/xcode/warnings/splitter/XcodeWarningsReportIssueSplitterTest.java
+++ b/sonar-apple-plugin/src/test/java/fr/insideapp/sonarqube/apple/xcode/warnings/splitter/XcodeWarningsReportIssueSplitterTest.java
@@ -20,6 +20,7 @@ package fr.insideapp.sonarqube.apple.xcode.warnings.splitter;
 import fr.insideapp.sonarqube.apple.commons.issues.ReportIssue;
 import fr.insideapp.sonarqube.apple.commons.warnings.XcodeWarningRulesDefinition;
 import fr.insideapp.sonarqube.objc.ObjectiveC;
+import fr.insideapp.sonarqube.objc.ObjectiveCExtensionProvider;
 import fr.insideapp.sonarqube.swift.Swift;
 import fr.insideapp.sonarqube.swift.SwiftExtensionProvider;
 import org.junit.Before;
@@ -57,7 +58,7 @@ public final class XcodeWarningsReportIssueSplitterTest {
     public void prepare() {
         configuration = mock(Configuration.class);
         swift = new Swift(configuration);
-        objc = new ObjectiveC();
+        objc = new ObjectiveC(configuration);
         swiftRulesDefinition = new XcodeWarningRulesDefinition(swift) {};
         objcRulesDefinition = new XcodeWarningRulesDefinition(objc) {};
         ActiveRulesBuilder builder = new ActiveRulesBuilder();
@@ -122,6 +123,8 @@ public final class XcodeWarningsReportIssueSplitterTest {
         when(configuration.getStringArray(SwiftExtensionProvider.FILE_SUFFIXES_KEY))
             .thenReturn(Swift.FILE_SUFFIXES.stream().toArray(String[]::new));
         ReportIssue reportIssue2 = new ReportIssue(buildRule(objcRulesDefinition.getLanguage()), "message", "path/to/file.m", 15);
+        when(configuration.getStringArray(ObjectiveCExtensionProvider.FILE_SUFFIXES_KEY))
+            .thenReturn(ObjectiveC.FILE_SUFFIXES.stream().toArray(String[]::new));
         // test
         Map<XcodeWarningRulesDefinition, List<ReportIssue>> issuesSplit = splitter.split(List.of(reportIssue1, reportIssue2), activeRules);
         // assert

--- a/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/Swift.java
+++ b/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/Swift.java
@@ -18,17 +18,34 @@
 package fr.insideapp.sonarqube.swift;
 
 import fr.insideapp.sonarqube.apple.commons.tests.LanguageTestFile;
+import org.apache.commons.lang3.StringUtils;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.resources.AbstractLanguage;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public final class Swift extends AbstractLanguage implements LanguageTestFile {
 
-    public Swift() {
+    public static final List<String> FILE_SUFFIXES = List.of("swift");
+
+    private Configuration configuration;
+    
+    public Swift(final Configuration configuration) {
         super("swift", "Swift");
+        this.configuration = configuration;
     }
 
     @Override
     public String[] getFileSuffixes() {
-        return new String[]{"swift"};
+        final List<String> providedFilesSuffixes = Arrays.asList(configuration.getStringArray(SwiftExtensionProvider.FILE_SUFFIXES_KEY))
+            .stream()
+            .map(String::trim)
+            .filter(StringUtils::isNotBlank)
+            .collect(Collectors.toList());
+        final List<String> filesSuffixes = providedFilesSuffixes.isEmpty() ? FILE_SUFFIXES : providedFilesSuffixes;
+        return filesSuffixes.stream().toArray(String[]::new);
     }
 
     @Override

--- a/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/SwiftExtensionProvider.java
+++ b/swift-lang/src/main/java/fr/insideapp/sonarqube/swift/SwiftExtensionProvider.java
@@ -23,17 +23,33 @@ import fr.insideapp.sonarqube.swift.antlr.SwiftCyclomaticComplexityVisitor;
 import fr.insideapp.sonarqube.swift.antlr.SwiftHighlighterVisitor;
 import fr.insideapp.sonarqube.swift.antlr.SwiftSourceLinesVisitor;
 import fr.insideapp.sonarqube.swift.issues.SwiftProfile;
+import org.sonar.api.config.PropertyDefinition;
+import org.sonar.api.resources.Qualifiers;
 import org.sonar.api.scanner.ScannerSide;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @ScannerSide
 public class SwiftExtensionProvider implements ExtensionProvider {
 
+    public static final String FILE_SUFFIXES_KEY = "sonar.swift.file.suffixes";
+    private static final PropertyDefinition FILE_SUFFIXES = PropertyDefinition
+        .builder(FILE_SUFFIXES_KEY)
+        .name("File Suffixes")
+        .description("List of suffixes of Swift files to analyze.")
+        .multiValues(true)
+        .category(APPLE_CATEGORY)
+        .subCategory("Swift")
+        .onQualifiers(Qualifiers.PROJECT)
+        .defaultValue(Swift.FILE_SUFFIXES.stream().collect(Collectors.joining(",")))
+        .build();
+
     public List<Object> extensions() {
         return Arrays.asList(
                 Swift.class,
+            FILE_SUFFIXES,
                 SwiftAntlrContext.class,
                 SwiftSourceLinesVisitor.class,
                 SwiftHighlighterVisitor.class,

--- a/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/SwiftExtensionProviderTest.java
+++ b/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/SwiftExtensionProviderTest.java
@@ -33,7 +33,7 @@ public final class SwiftExtensionProviderTest {
 
     @Test
     public void extensions() {
-        assertThat(provider.extensions()).hasSize(7);
+        assertThat(provider.extensions()).hasSize(8);
     }
 
 }

--- a/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/SwiftLanguageTestFileFinderTest.java
+++ b/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/SwiftLanguageTestFileFinderTest.java
@@ -15,9 +15,9 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package fr.insideapp.sonarqube.swift.tests;
+package fr.insideapp.sonarqube.swift;
 
-import fr.insideapp.sonarqube.swift.Swift;
+import fr.insideapp.sonarqube.swift.tests.SwiftLanguageTestFileFinder;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -25,14 +25,18 @@ import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.internal.DefaultFileSystem;
 import org.sonar.api.batch.fs.internal.DefaultInputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
+import org.sonar.api.config.Configuration;
 
 import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
 public final class SwiftLanguageTestFileFinderTest {
 
     private static final String BASE_DIR = "/swift";
     private final File baseDir = FileUtils.toFile(getClass().getResource(BASE_DIR));
+    private Configuration configuration;
 
     private SwiftLanguageTestFileFinder fileFinder;
     private DefaultFileSystem fileSystem;
@@ -41,7 +45,8 @@ public final class SwiftLanguageTestFileFinderTest {
 
     @Before
     public void prepare() {
-        swift = new Swift();
+        configuration = mock(Configuration.class);
+        swift = new Swift(configuration);
         fileFinder = new SwiftLanguageTestFileFinder(swift);
         fileSystem = new DefaultFileSystem(baseDir);
     }

--- a/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/SwiftSensorTest.java
+++ b/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/SwiftSensorTest.java
@@ -26,12 +26,15 @@ import org.junit.Test;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.config.Configuration;
 
 import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public final class SwiftSensorTest {
+    private Configuration configuration;
 
     private SwiftSensor sensor;
     private SensorContextTester context;
@@ -40,7 +43,8 @@ public final class SwiftSensorTest {
 
     @Before
     public void prepare() {
-        swift = new Swift();
+        configuration = mock(Configuration.class);
+        swift = new Swift(configuration);
         context = SensorContextTester.create(new File("."));
         sensor = new SwiftSensor(
                 swift,

--- a/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/SwiftTest.java
+++ b/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/SwiftTest.java
@@ -1,0 +1,66 @@
+package fr.insideapp.sonarqube.swift;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.sonar.api.config.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public final class SwiftTest {
+
+    private Swift swift;
+    private Configuration configuration;
+
+    @Before
+    public void prepare() {
+        configuration = mock(Configuration.class);
+        swift = new Swift(configuration);
+    }
+
+    @Test
+    public void fileSuffixes_default() {
+        // prepare
+        when(configuration.getStringArray(SwiftExtensionProvider.FILE_SUFFIXES_KEY))
+            .thenReturn(new String[]{});
+        // test
+        final String[] fileSuffixes = swift.getFileSuffixes();
+        // prepare
+        assertThat(fileSuffixes).containsAll(Swift.FILE_SUFFIXES);
+    }
+
+    @Test
+    public void fileSuffixes_custom() {
+        // prepare
+        when(configuration.getStringArray(SwiftExtensionProvider.FILE_SUFFIXES_KEY))
+            .thenReturn(new String[]{"foo", "bar"});
+        // test
+        final String[] fileSuffixes = swift.getFileSuffixes();
+        // prepare
+        assertThat(fileSuffixes).containsExactlyInAnyOrder("foo", "bar");
+    }
+
+    @Test
+    public void fileSuffixes_custom_but_not_good() {
+        // prepare
+        when(configuration.getStringArray(SwiftExtensionProvider.FILE_SUFFIXES_KEY))
+            .thenReturn(new String[]{"", "  "});
+        // test
+        final String[] fileSuffixes = swift.getFileSuffixes();
+        // prepare
+        assertThat(fileSuffixes).containsAll(Swift.FILE_SUFFIXES);
+    }
+
+    @Test
+    public void fileSuffixes_custom_with_spaces() {
+        // prepare
+        when(configuration.getStringArray(SwiftExtensionProvider.FILE_SUFFIXES_KEY))
+            .thenReturn(new String[]{"foo  ", "  bar", "", "  "});
+        // test
+        final String[] fileSuffixes = swift.getFileSuffixes();
+        // prepare
+        assertThat(fileSuffixes).containsExactlyInAnyOrder("foo", "bar");
+    }
+
+}

--- a/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/SwiftTest.java
+++ b/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/SwiftTest.java
@@ -1,3 +1,20 @@
+/*
+ * SonarQube Apple Plugin - Enables analysis of Swift and Objective-C projects into SonarQube.
+ * Copyright © 2022 inside|app (contact@insideapp.fr)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package fr.insideapp.sonarqube.swift;
 
 import org.junit.Before;

--- a/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/antlr/SwiftCyclomaticComplexityVisitorTest.java
+++ b/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/antlr/SwiftCyclomaticComplexityVisitorTest.java
@@ -19,6 +19,7 @@ package fr.insideapp.sonarqube.swift.antlr;
 
 import fr.insideapp.sonarqube.apple.commons.antlr.CustomTreeVisitor;
 import fr.insideapp.sonarqube.swift.Swift;
+import fr.insideapp.sonarqube.swift.SwiftExtensionProvider;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,6 +27,7 @@ import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.batch.sensor.measure.Measure;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.measures.CoreMetrics;
 
 import java.io.File;
@@ -34,6 +36,8 @@ import java.nio.charset.Charset;
 import java.nio.file.Paths;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class SwiftCyclomaticComplexityVisitorTest {
 
@@ -49,6 +53,7 @@ public class SwiftCyclomaticComplexityVisitorTest {
 
     private static final String BASE_DIR = "src/test/resources/swift/cyclomatic_complexity";
     private SensorContextTester sensorContext;
+    private Configuration configuration;
 
     private Swift swift;
     private SwiftAntlrContext antlrContext;
@@ -57,7 +62,8 @@ public class SwiftCyclomaticComplexityVisitorTest {
 
     @Before
     public void prepare() {
-        swift = new Swift();
+        configuration = mock(Configuration.class);
+        swift = new Swift(configuration);
         sensorContext = SensorContextTester.create(new File(BASE_DIR));
         antlrContext = new SwiftAntlrContext();
         visitor = new SwiftCyclomaticComplexityVisitor();
@@ -66,54 +72,51 @@ public class SwiftCyclomaticComplexityVisitorTest {
 
     @Test
     public void testCase1() throws IOException {
-        assertContainer(new SwiftCyclomaticComplexityVisitorTest.Container("ComplexityCase1", 4));
+        assertContainer(new SwiftCyclomaticComplexityVisitorTest.Container("ComplexityCase1.swift", 4));
     }
 
     @Test
     public void testCase2() throws IOException {
-        assertContainer(new SwiftCyclomaticComplexityVisitorTest.Container("ComplexityCase2", 10));
+        assertContainer(new SwiftCyclomaticComplexityVisitorTest.Container("ComplexityCase2.swift", 10));
     }
 
     @Test
     public void testCase3() throws IOException {
-        assertContainer(new SwiftCyclomaticComplexityVisitorTest.Container("ComplexityCase3", 13));
+        assertContainer(new SwiftCyclomaticComplexityVisitorTest.Container("ComplexityCase3.swift", 13));
     }
 
     @Test
     public void testCase4() throws IOException {
-        assertContainer(new SwiftCyclomaticComplexityVisitorTest.Container("ComplexityCase4", 11));
+        assertContainer(new SwiftCyclomaticComplexityVisitorTest.Container("ComplexityCase4.swift", 11));
     }
 
     @Test
     public void testCase5() throws IOException {
-        assertContainer(new SwiftCyclomaticComplexityVisitorTest.Container("ComplexityCase5", 8));
+        assertContainer(new SwiftCyclomaticComplexityVisitorTest.Container("ComplexityCase5.swift", 8));
     }
 
     @Test
     public void testCase6() throws IOException {
-        assertContainer(new SwiftCyclomaticComplexityVisitorTest.Container("ComplexityCase6", 3));
+        assertContainer(new SwiftCyclomaticComplexityVisitorTest.Container("ComplexityCase6.swift", 3));
     }
 
     @Test
     public void testCase7() throws IOException {
-        assertContainer(new SwiftCyclomaticComplexityVisitorTest.Container("ComplexityCase7", 2));
+        assertContainer(new SwiftCyclomaticComplexityVisitorTest.Container("ComplexityCase7.swift", 2));
     }
 
     @Test
     public void testCase8() throws IOException {
-        assertContainer(new SwiftCyclomaticComplexityVisitorTest.Container("ComplexityCase8", 2));
+        assertContainer(new SwiftCyclomaticComplexityVisitorTest.Container("ComplexityCase8.swift", 2));
     }
 
     private void assertContainer(SwiftCyclomaticComplexityVisitorTest.Container container) throws IOException {
-
-        final String completeFileName = container.fileName + "." + swift.getFileSuffixes()[0];
-
         // Real file
-        File file = new File(BASE_DIR, completeFileName);
+        File file = new File(BASE_DIR, container.fileName);
 
         // Mock file for test purpose
         // Setting it up with the real file properties
-        InputFile inputFile = new TestInputFileBuilder("", completeFileName)
+        InputFile inputFile = new TestInputFileBuilder("", container.fileName)
                 .setLanguage(swift.getKey())
                 .setModuleBaseDir(Paths.get(BASE_DIR))
                 .setContents(FileUtils.readFileToString(file, Charset.defaultCharset()))

--- a/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/issues/SwiftProfileTest.java
+++ b/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/issues/SwiftProfileTest.java
@@ -25,11 +25,14 @@ import fr.insideapp.sonarqube.swift.issues.swiftlint.SwiftLintRulesDefinition;
 import fr.insideapp.sonarqube.swift.issues.warnings.XcodeWarningSwiftRulesDefinition;
 import org.junit.Before;
 import org.junit.Test;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public final class SwiftProfileTest {
+    private Configuration configuration;
 
     private Swift swift;
 
@@ -39,7 +42,8 @@ public final class SwiftProfileTest {
 
     @Before
     public void prepare() {
-        swift = new Swift();
+        configuration = mock(Configuration.class);
+        swift = new Swift(configuration);
         context = new BuiltInQualityProfilesDefinition.Context();
         profile = new SwiftProfile(
                 swift,

--- a/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/issues/mobsfscan/MobSFScanSwiftRulesDefinitionTest.java
+++ b/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/issues/mobsfscan/MobSFScanSwiftRulesDefinitionTest.java
@@ -21,11 +21,14 @@ import fr.insideapp.sonarqube.apple.commons.rules.MobSFScanRulesDefinition;
 import fr.insideapp.sonarqube.swift.Swift;
 import org.junit.Before;
 import org.junit.Test;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.server.rule.RulesDefinition;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public final class MobSFScanSwiftRulesDefinitionTest {
+    private Configuration configuration;
 
     private MobSFScanRulesDefinition rulesDefinition;
     private Swift language;
@@ -33,7 +36,8 @@ public final class MobSFScanSwiftRulesDefinitionTest {
 
     @Before
     public void prepare() {
-        language = new Swift();
+        configuration = mock(Configuration.class);
+        language = new Swift(configuration);
         rulesDefinition = new MobSFScanSwiftRulesDefinition(language);
         context = new RulesDefinition.Context();
     }

--- a/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/issues/periphery/PeripheryRulesDefinitionTest.java
+++ b/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/issues/periphery/PeripheryRulesDefinitionTest.java
@@ -21,11 +21,14 @@ import fr.insideapp.sonarqube.apple.commons.rules.JSONRulesDefinition;
 import fr.insideapp.sonarqube.swift.Swift;
 import org.junit.Before;
 import org.junit.Test;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.server.rule.RulesDefinition;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class PeripheryRulesDefinitionTest {
+    private Configuration configuration;
 
     private JSONRulesDefinition rulesDefinition;
     private Swift language;
@@ -33,7 +36,8 @@ public class PeripheryRulesDefinitionTest {
 
     @Before
     public void prepare() {
-        language = new Swift();
+        configuration = mock(Configuration.class);
+        language = new Swift(configuration);
         rulesDefinition = new PeripheryRulesDefinition(language);
         context = new RulesDefinition.Context();
     }

--- a/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/issues/periphery/PeripherySensorTest.java
+++ b/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/issues/periphery/PeripherySensorTest.java
@@ -31,6 +31,7 @@ import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.batch.sensor.issue.Issue;
+import org.sonar.api.config.Configuration;
 
 import java.io.File;
 import java.nio.file.Paths;
@@ -48,6 +49,7 @@ public final class PeripherySensorTest {
 
     private static final String BASE_DIR = "/swift/periphery";
     private final File baseDir = FileUtils.toFile(getClass().getResource(BASE_DIR));
+    private Configuration configuration;
 
     private PeripherySensor sensor;
     private Swift swift;
@@ -64,7 +66,8 @@ public final class PeripherySensorTest {
         parser = mock(PeripheryReportParsable.class);
         mapper = mock(PeripheryReportMappable.class);
         rulesDefinition = mock(PeripheryRulesDefinition.class);
-        swift = new Swift();
+        configuration = mock(Configuration.class);
+        swift = new Swift(configuration);
         sensor = new PeripherySensor(
                 swift,
                 rulesDefinition,

--- a/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/issues/swiftlint/SwiftLintExtensionProviderTest.java
+++ b/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/issues/swiftlint/SwiftLintExtensionProviderTest.java
@@ -17,6 +17,7 @@
  */
 package fr.insideapp.sonarqube.swift.issues.swiftlint;
 
+import fr.insideapp.sonarqube.swift.issues.swiftlint.SwiftLintExtensionProvider;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/issues/swiftlint/SwiftLintRulesDefinitionTest.java
+++ b/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/issues/swiftlint/SwiftLintRulesDefinitionTest.java
@@ -21,19 +21,23 @@ import fr.insideapp.sonarqube.apple.commons.rules.JSONRulesDefinition;
 import fr.insideapp.sonarqube.swift.Swift;
 import org.junit.Before;
 import org.junit.Test;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.server.rule.RulesDefinition;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class SwiftLintRulesDefinitionTest {
 
+    private Configuration configuration;
     private JSONRulesDefinition rulesDefinition;
     private Swift language;
     private RulesDefinition.Context context;
 
     @Before
     public void prepare() {
-        language = new Swift();
+        configuration = mock(Configuration.class);
+        language = new Swift(configuration);
         rulesDefinition = new SwiftLintRulesDefinition(language);
         context = new RulesDefinition.Context();
     }

--- a/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/issues/swiftlint/SwiftLintSensorTest.java
+++ b/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/issues/swiftlint/SwiftLintSensorTest.java
@@ -31,6 +31,7 @@ import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.batch.sensor.issue.Issue;
+import org.sonar.api.config.Configuration;
 
 import java.io.File;
 import java.nio.file.Paths;
@@ -49,6 +50,7 @@ public class SwiftLintSensorTest {
     private static final String BASE_DIR = "/swift/swiftlint";
     private final File baseDir = FileUtils.toFile(getClass().getResource(BASE_DIR));
 
+    private Configuration configuration;
     private SwiftLintSensor sensor;
     private Swift swift;
     private SensorContextTester context;
@@ -64,7 +66,8 @@ public class SwiftLintSensorTest {
         parser = mock(SwiftLintReportParsable.class);
         mapper = mock(SwiftLintReportMappable.class);
         rulesDefinition = mock(SwiftLintRulesDefinition.class);
-        swift = new Swift();
+        configuration = mock(Configuration.class);
+        swift = new Swift(configuration);
         sensor = new SwiftLintSensor(
                 swift,
                 rulesDefinition,

--- a/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/issues/warnings/XcodeWarningSwiftRulesDefinitionTest.java
+++ b/swift-lang/src/test/java/fr/insideapp/sonarqube/swift/issues/warnings/XcodeWarningSwiftRulesDefinitionTest.java
@@ -21,11 +21,14 @@ import fr.insideapp.sonarqube.apple.commons.rules.JSONRulesDefinition;
 import fr.insideapp.sonarqube.swift.Swift;
 import org.junit.Before;
 import org.junit.Test;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.server.rule.RulesDefinition;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class XcodeWarningSwiftRulesDefinitionTest {
+    private Configuration configuration;
 
     private JSONRulesDefinition rulesDefinition;
     private Swift language;
@@ -33,7 +36,8 @@ public class XcodeWarningSwiftRulesDefinitionTest {
 
     @Before
     public void prepare() {
-        language = new Swift();
+        configuration = mock(Configuration.class);
+        language = new Swift(configuration);
         rulesDefinition = new XcodeWarningSwiftRulesDefinition(language);
         context = new RulesDefinition.Context();
     }


### PR DESCRIPTION
# Summary 

This PR aims to fix https://github.com/insideapp-oss/sonar-apple/issues/82
Adding file suffixes seems to fix the issue and the analysis works.

# Results

## Before

```
11:21:55.521 DEBUG: Declared patterns of language Swift were converted to sonar.lang.patterns.swift : 
11:21:55.523 DEBUG: Declared patterns of language Objective-C were converted to sonar.lang.patterns.objc : 
```

## After

```
17:38:24.340 DEBUG: Declared patterns of language Swift were converted to sonar.lang.patterns.swift : **/*.swift
17:38:24.342 DEBUG: Declared patterns of language Objective-C were converted to sonar.lang.patterns.objc : **/*.h,**/*.m,**/*.mm
```

## UI

![Capture d’écran 2024-02-29 à 17 49 25](https://github.com/insideapp-oss/sonar-apple/assets/2591243/7f87f130-0d97-4426-954d-41a840a54fcd)
![Capture d’écran 2024-02-29 à 17 49 32](https://github.com/insideapp-oss/sonar-apple/assets/2591243/0e2f53e2-c034-4a17-ba9e-963cb8d78dcb)

# DoD

- [x] Implementation
- [x] Unit tests