### PR TITLE
Use sonar.token instead of sonar.login

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         mvn verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
-        -Dsonar.login=$SONAR_TOKEN \
+        -Dsonar.token=$SONAR_TOKEN \
         -Dsonar.host.url=https://sonarcloud.io \
         -Dsonar.organization=insideapp-oss \
         -Dsonar.projectKey=insideapp-oss_sonar-apple

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mvn verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
-          -Dsonar.login=$SONAR_TOKEN \
+          -Dsonar.token=$SONAR_TOKEN \
           -Dsonar.host.url=https://sonarcloud.io \
           -Dsonar.organization=insideapp-oss \
           -Dsonar.projectKey=insideapp-oss_sonar-apple

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ xcrun xcodebuild \
   clean test
 
 # Run the analysis and publish to the SonarQube server
-# Don't forget to specify `sonar.host.url` and `sonar.login` in `sonar-project.properties` or supply it to the following command.
+# Don't forget to specify `sonar.host.url` and `sonar.token` in `sonar-project.properties` or supply it to the following command.
 sonar-scanner
 ```
 


### PR DESCRIPTION
# Summary 

This PR aims to fix a deprecation warning

```Warning:  The property 'sonar.login' is deprecated and will be removed in the future. Please use the 'sonar.token' property instead when passing a token.```