### PR TITLE
Fix Sonar API Version to target SonarQube 9.9

### DIFF
--- a/commons/src/main/java/fr/insideapp/sonarqube/apple/commons/antlr/ParseTreeAnalyzer.java
+++ b/commons/src/main/java/fr/insideapp/sonarqube/apple/commons/antlr/ParseTreeAnalyzer.java
@@ -17,19 +17,19 @@
  */
 package fr.insideapp.sonarqube.apple.commons.antlr;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.fs.FilePredicate;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.InputFile.Type;
 import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
 
 public class ParseTreeAnalyzer {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ParseTreeAnalyzer.class);
+    private static final Logger LOGGER = Loggers.get(ParseTreeAnalyzer.class);
 
     private final String languageKey;
     private final Type type;

--- a/commons/src/main/java/fr/insideapp/sonarqube/apple/commons/issues/ReportIssueRecorder.java
+++ b/commons/src/main/java/fr/insideapp/sonarqube/apple/commons/issues/ReportIssueRecorder.java
@@ -17,8 +17,6 @@
  */
 package fr.insideapp.sonarqube.apple.commons.issues;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.fs.FilePredicate;
 import org.sonar.api.batch.fs.FilePredicates;
 import org.sonar.api.batch.fs.FileSystem;
@@ -28,13 +26,15 @@ import org.sonar.api.batch.sensor.issue.NewIssue;
 import org.sonar.api.batch.sensor.issue.NewIssueLocation;
 import org.sonar.api.rule.RuleKey;
 import org.sonar.api.scanner.ScannerSide;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 
 import java.util.List;
 
 @ScannerSide
 public final class ReportIssueRecorder {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ReportIssueRecorder.class);
+    private static final Logger LOGGER = Loggers.get(ReportIssueRecorder.class);
 
     public void recordIssues(List<ReportIssue> issues, String repository, SensorContext sensorContext) {
 

--- a/pom.xml
+++ b/pom.xml
@@ -90,12 +90,10 @@
         <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <!-- we depend on API ${sonar.version} but we keep backward compatibility with LTS -->
-        <pluginApiMinVersion>9.9</pluginApiMinVersion>
-
         <!-- versions -->
-        <sonar.api.version>10.5.0.2090</sonar.api.version>
-        <sonar.version>9.9.1.69595</sonar.version>
+        <!-- see: https://github.com/SonarSource/sonar-plugin-api?tab=readme-ov-file#sonarqube -->
+        <sonar.api.version>9.14.0.375</sonar.api.version>
+        <sonar.version>9.9.0.65466</sonar.version>
         <sonar-analyzer-commons.version>2.7.0.1482</sonar-analyzer-commons.version>
         <sslr.version>1.24.0.633</sslr.version>
         <commons.io.version>2.15.1</commons.io.version>

--- a/sonar-apple-plugin/pom.xml
+++ b/sonar-apple-plugin/pom.xml
@@ -67,7 +67,7 @@
                     <pluginKey>sonar-apple</pluginKey>
                     <pluginClass>fr.insideapp.sonarqube.apple.ApplePlugin</pluginClass>
                     <pluginName>Swift/Objective-C Code Quality and Security</pluginName>
-                    <pluginApiMinVersion>${pluginApiMinVersion}</pluginApiMinVersion>
+                    <pluginApiMinVersion>${sonar.api.version}</pluginApiMinVersion>
                     <jreMinVersion>${jre.min.version}</jreMinVersion>
                 </configuration>
             </plugin>

--- a/sonar-apple-plugin/src/main/java/fr/insideapp/sonarqube/apple/xcode/coverage/recorder/XcodeCoverageRecorder.java
+++ b/sonar-apple-plugin/src/main/java/fr/insideapp/sonarqube/apple/xcode/coverage/recorder/XcodeCoverageRecorder.java
@@ -19,20 +19,20 @@ package fr.insideapp.sonarqube.apple.xcode.coverage.recorder;
 
 import fr.insideapp.sonarqube.apple.xcode.coverage.models.XcodeCodeCoverage;
 import fr.insideapp.sonarqube.apple.xcode.coverage.models.XcodeCodeCoverageMetadata;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.fs.FilePredicate;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.coverage.NewCoverage;
 import org.sonar.api.scanner.ScannerSide;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 
 import java.util.List;
 
 @ScannerSide
 public final class XcodeCoverageRecorder implements XcodeCoverageRecordable {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(XcodeCoverageRecorder.class);
+    private static final Logger LOGGER = Loggers.get(XcodeCoverageRecorder.class);
 
     private final SensorContext context;
 

--- a/sonar-apple-plugin/src/main/java/fr/insideapp/sonarqube/apple/xcode/tests/recorder/XcodeTestsRecorder.java
+++ b/sonar-apple-plugin/src/main/java/fr/insideapp/sonarqube/apple/xcode/tests/recorder/XcodeTestsRecorder.java
@@ -21,13 +21,13 @@ import fr.insideapp.sonarqube.apple.xcode.tests.XcodeTestFileFindable;
 import fr.insideapp.sonarqube.apple.xcode.tests.models.XcodeTestSummary;
 import fr.insideapp.sonarqube.apple.xcode.tests.models.XcodeTestClassReport;
 import fr.insideapp.sonarqube.apple.xcode.tests.models.XcodeTestGroup;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.measures.CoreMetrics;
 import org.sonar.api.measures.Metric;
 import org.sonar.api.scanner.ScannerSide;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 
 import javax.annotation.CheckForNull;
 import java.io.Serializable;
@@ -42,7 +42,7 @@ public final class XcodeTestsRecorder implements XcodeTestsRecordable {
         this.finder = finder;
     }
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(XcodeTestsRecorder.class);
+    private static final Logger LOGGER = Loggers.get(XcodeTestsRecorder.class);
 
     @Override
     public void save(List<XcodeTestSummary> testSummaries, SensorContext context) {


### PR DESCRIPTION
# Summary 

This PR fixes a mistake introduced in #87.
SonarQube 10.5.0.2090 was wrongfully targeted instead of the minimal 9.9.

## Details

I found a correlation table between the SonarQube Plugin API version and the SonarQube version.
To match the SonarQube 9.9 version (9.9.0.65466), we need to use the SonarQube Plugin API version 9.14.0.375.
Not trivial.

https://github.com/SonarSource/sonar-plugin-api/?tab=readme-ov-file#sonarqube
